### PR TITLE
Fixes the issue of JavaFX application not exiting properly

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/PDFViewSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/PDFViewSkin.java
@@ -90,7 +90,11 @@ import java.util.stream.Collectors;
 public class PDFViewSkin extends SkinBase<PDFView> {
 
     // Access to PDF document must be single threaded (see Apache PdfBox website FAQs)
-    private final Executor EXECUTOR = Executors.newSingleThreadExecutor();
+    private final Executor EXECUTOR = Executors.newSingleThreadExecutor(r -> {
+        Thread thread = new Thread(r, PDFView.class.getSimpleName() + " Thread");
+        thread.setDaemon(true);
+        return thread;
+    });
 
     private final ObservableList<Integer> pdfFilePages = FXCollections.observableArrayList();
     private final BorderPane borderPane;


### PR DESCRIPTION
Fixes this issue: #4 

The fix can be verified by running `PDFViewApp` and closing it. It should exit immediately. 