### PR TITLE
Add total number of pages indicator

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/PDFView.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/PDFView.java
@@ -274,6 +274,17 @@ public class PDFView extends Control {
     }
 
     /**
+     * Convenience method to show the last page.
+     *
+     * @return true if the operation actually did cause a page change
+     */
+    public final boolean gotoLastPage() {
+        int currentPage = getPage();
+        setPage(getDocument().getNumberOfPages() - 1);
+        return currentPage != getPage();
+    }
+
+    /**
      * A flag that controls whether we always want to show the entire page. If "true" then the page
      * will be constantly resized to fit the viewport of the scroll pane in which it is showing. In
      * this mode zooming is not possible.

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/PDFViewSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/PDFViewSkin.java
@@ -337,11 +337,15 @@ public class PDFViewSkin extends SkinBase<PDFView> {
         pageField.setTooltip(new Tooltip("Current page number"));
         pageField.getStyleClass().add("page-field");
         pageField.setAllowNegatives(false);
-        pageField.setMinimumValue(1);
         pageField.setMaxHeight(Double.MAX_VALUE);
         pageField.setAlignment(Pos.CENTER);
-        pageField.setValue(view.getPage() + 1);
-        view.pageProperty().addListener(it -> pageField.setValue(view.getPage() + 1));
+        pageField.setMinimumValue(0);
+        pageField.setValue(0);
+        view.pageProperty().addListener(it -> {
+                    pageField.setMinimumValue(1);
+                    pageField.setValue(view.getPage() + 1);
+                }
+        );
         pageField.valueProperty().addListener(it -> {
             final Integer value = pageField.getValue();
             if (value != null) {
@@ -351,7 +355,16 @@ public class PDFViewSkin extends SkinBase<PDFView> {
         updateMaximumValue(pageField);
         view.documentProperty().addListener(it -> updateMaximumValue(pageField));
 
-        HBox pageControl = new HBox(goLeft, pageField, goRight);
+        Button totalPages = new Button();
+        totalPages.setTooltip(new Tooltip("Total number of pages"));
+        totalPages.getStyleClass().add("page-number-button");
+        totalPages.setMaxHeight(Double.MAX_VALUE);
+        totalPages.setAlignment(Pos.CENTER);
+        totalPages.setOnAction(event -> view.gotoLastPage());
+        updateTotalPagesNumber(totalPages);
+        view.documentProperty().addListener(it -> updateTotalPagesNumber(totalPages));
+
+        HBox pageControl = new HBox(goLeft, pageField, totalPages, goRight);
         pageControl.setFillHeight(true);
         pageControl.disableProperty().bind(view.documentProperty().isNull());
         pageControl.getStyleClass().add("page-control");
@@ -482,6 +495,15 @@ public class PDFViewSkin extends SkinBase<PDFView> {
         PDFView.Document document = getSkinnable().getDocument();
         if (document != null) {
             pageField.setMaximumValue(document.getNumberOfPages());
+        }
+    }
+
+    private void updateTotalPagesNumber(Button totalPagesButton) {
+        PDFView.Document document = getSkinnable().getDocument();
+        if (document != null) {
+            totalPagesButton.setText("/ " + document.getNumberOfPages());
+        } else {
+            totalPagesButton.setText("/ " + 0);
         }
     }
 

--- a/gemsfx/src/main/resources/com/dlsc/gemsfx/pdf-view.css
+++ b/gemsfx/src/main/resources/com/dlsc/gemsfx/pdf-view.css
@@ -139,6 +139,10 @@
     -fx-background-radius: 3 0 0 3, 3 0 0 3, 2 0 0 2, 1 0 0 1;
 }
 
+.pdf-view .page-control .page-number-button {
+    -fx-background-radius: 0 0 0 0, 0 0 0 0, 0 0 0 0, 0 0 0 0;
+}
+
 .pdf-view .page-control .next-page-button {
     -fx-background-radius: 0 3 3 0, 0 3 3 0, 0 2 2 0, 0 1 1 0;
 }


### PR DESCRIPTION
Majority (if not all) of PDF preview applications will show a total number of pages of a currently opened document.

This PR adds total pages indicator which is at the same time also a button for convenient jump to the last page.

It looks like this:
![total-number-of-pages](https://user-images.githubusercontent.com/1519324/79328405-48772f80-7f16-11ea-9398-f67f7c782a5f.PNG)

Side note:
I haven't opened a new issue for this as I think it's not necessary. Please let me know if you would prefer to open it (for every PR) in the future.
