### PR TITLE
Closing of current document

### DIFF
--- a/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/PDFViewApp.java
+++ b/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/PDFViewApp.java
@@ -2,6 +2,8 @@ package com.dlsc.gemsfx.demo;
 
 import com.dlsc.gemsfx.PDFView;
 import javafx.application.Application;
+import javafx.beans.binding.Bindings;
+import javafx.collections.ObservableList;
 import javafx.scene.Scene;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
@@ -21,7 +23,7 @@ public class PDFViewApp extends Application {
 
     @Override
     public void start(Stage primaryStage) {
-        PDFView view = new PDFView();
+        PDFView pdfView = new PDFView();
 
         MenuItem loadItem = new MenuItem("Load PDF ...");
         loadItem.setAccelerator(KeyCombination.valueOf("SHORTCUT+o"));
@@ -34,20 +36,27 @@ public class PDFViewApp extends Application {
                 chooser.setSelectedExtensionFilter(filter);
             }
 
-            final File file = chooser.showOpenDialog(view.getScene().getWindow());
+            final File file = chooser.showOpenDialog(pdfView.getScene().getWindow());
             if (file != null) {
-                view.load(file);
+                pdfView.load(file);
             }
         });
 
+        MenuItem closeItem = new MenuItem("Close PDF ...");
+        closeItem.setAccelerator(KeyCombination.valueOf("SHORTCUT+c"));
+        closeItem.setOnAction(evt -> pdfView.unload());
+        closeItem.disableProperty().bind(Bindings.isNull(pdfView.documentProperty()));
+
         Menu fileMenu = new Menu("File");
-        fileMenu.getItems().add(loadItem);
+        ObservableList<MenuItem> fileMenuItems = fileMenu.getItems();
+        fileMenuItems.add(loadItem);
+        fileMenuItems.add(closeItem);
 
         MenuBar menuBar = new MenuBar(fileMenu);
         menuBar.setUseSystemMenuBar(false);
 
-        VBox.setVgrow(view, Priority.ALWAYS);
-        VBox box = new VBox(menuBar, view);
+        VBox.setVgrow(pdfView, Priority.ALWAYS);
+        VBox box = new VBox(menuBar, pdfView);
         box.setFillWidth(true);
 
         Scene scene = new Scene(box);

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/PDFView.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/PDFView.java
@@ -468,6 +468,16 @@ public class PDFView extends Control {
         setDocument(supplier.get());
     }
 
+    /**
+     * Un-loads currently loaded document.
+     */
+    public final void unload() {
+        setDocument(null);
+        setSearchText(null);
+        setZoomFactor(1);
+        setRotate(0);
+    }
+
     public interface Document {
 
         BufferedImage renderPage(int pageNumber, float scale);

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/PDFViewSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/PDFViewSkin.java
@@ -203,6 +203,7 @@ public class PDFViewSkin extends SkinBase<PDFView> {
         getChildren().add(borderPane);
 
         view.documentProperty().addListener(it -> {
+            mainArea.setImage(null);
             imageCache.clear();
             view.setPage(-1);
             view.setPage(0);

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/PDFViewSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/PDFViewSkin.java
@@ -341,12 +341,8 @@ public class PDFViewSkin extends SkinBase<PDFView> {
         pageField.setMaxHeight(Double.MAX_VALUE);
         pageField.setAlignment(Pos.CENTER);
         pageField.setMinimumValue(0);
-        pageField.setValue(0);
-        view.pageProperty().addListener(it -> {
-                    pageField.setMinimumValue(1);
-                    pageField.setValue(view.getPage() + 1);
-                }
-        );
+        updateCurrentPageNumber(view, pageField);
+        view.pageProperty().addListener(it -> updateCurrentPageNumber(view, pageField));
         pageField.valueProperty().addListener(it -> {
             final Integer value = pageField.getValue();
             if (value != null) {
@@ -496,6 +492,16 @@ public class PDFViewSkin extends SkinBase<PDFView> {
         PDFView.Document document = getSkinnable().getDocument();
         if (document != null) {
             pageField.setMaximumValue(document.getNumberOfPages());
+        }
+    }
+
+    private void updateCurrentPageNumber(PDFView view, IntegerInputField pageField) {
+        if (view.getDocument() != null) {
+            pageField.setMinimumValue(1);
+            pageField.setValue(view.getPage() + 1);
+        } else {
+            pageField.setMinimumValue(0);
+            pageField.setValue(0);
         }
     }
 


### PR DESCRIPTION
Currently there is no way to unload currently loaded document. This might be desired in certain situations.

This PR adds new `PDFView.unload()` method which unloads currently loaded document and resets UI to its initial state.

Also added `Close PDF ...` menu item to the `PDFViewApp` demo application.