### PR TITLE
Added option to zoom document with the use of ctrl+scroll

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/PDFView.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/PDFView.java
@@ -285,35 +285,6 @@ public class PDFView extends Control {
     }
 
     /**
-     * Convenience method to decrease the zoom factor for value specified as {@code delta}.
-     *
-     * @param delta zoom factor (decrese) delta
-     * @return true if the operation actually did cause a zoom change
-     */
-
-    public final boolean decreaseZoomFactor(double delta) {
-        double currentZoomFactor = getZoomFactor();
-        if (!showAll.get()) {
-            setZoomFactor(Math.max(1, currentZoomFactor - delta));
-        }
-        return currentZoomFactor != getZoomFactor();
-    }
-
-    /**
-     * Convenience method to increase the zoom factor for value specified as {@code delta}.
-     *
-     * @param delta zoom factor (increase) delta
-     * @return true if the operation actually did cause a zoom change
-     */
-    public final boolean increaseZoomFactor(double delta) {
-        double currentZoomFactor = getZoomFactor();
-        if (!showAll.get()) {
-            setZoomFactor(Math.min(getMaxZoomFactor(), currentZoomFactor + delta));
-        }
-        return currentZoomFactor != getZoomFactor();
-    }
-
-    /**
      * A flag that controls whether we always want to show the entire page. If "true" then the page
      * will be constantly resized to fit the viewport of the scroll pane in which it is showing. In
      * this mode zooming is not possible.

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/PDFView.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/PDFView.java
@@ -285,6 +285,35 @@ public class PDFView extends Control {
     }
 
     /**
+     * Convenience method to decrease the zoom factor for value specified as {@code delta}.
+     *
+     * @param delta zoom factor (decrese) delta
+     * @return true if the operation actually did cause a zoom change
+     */
+
+    public final boolean decreaseZoomFactor(double delta) {
+        double currentZoomFactor = getZoomFactor();
+        if (!showAll.get()) {
+            setZoomFactor(Math.max(1, currentZoomFactor - delta));
+        }
+        return currentZoomFactor != getZoomFactor();
+    }
+
+    /**
+     * Convenience method to increase the zoom factor for value specified as {@code delta}.
+     *
+     * @param delta zoom factor (increase) delta
+     * @return true if the operation actually did cause a zoom change
+     */
+    public final boolean increaseZoomFactor(double delta) {
+        double currentZoomFactor = getZoomFactor();
+        if (!showAll.get()) {
+            setZoomFactor(Math.min(getMaxZoomFactor(), currentZoomFactor + delta));
+        }
+        return currentZoomFactor != getZoomFactor();
+    }
+
+    /**
      * A flag that controls whether we always want to show the entire page. If "true" then the page
      * will be constantly resized to fit the viewport of the scroll pane in which it is showing. In
      * this mode zooming is not possible.

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/PDFViewSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/PDFViewSkin.java
@@ -507,6 +507,37 @@ public class PDFViewSkin extends SkinBase<PDFView> {
         }
     }
 
+    /**
+     * Method to decrease the zoom factor for value specified as {@code delta}.
+     *
+     * @param delta zoom factor (decrease) delta
+     * @return true if the operation actually did cause a zoom change
+     */
+
+    private boolean decreaseZoomFactor(double delta) {
+        final PDFView pdfView = getSkinnable();
+        final double currentZoomFactor = pdfView.getZoomFactor();
+        if (!pdfView.isShowAll()) {
+            pdfView.setZoomFactor(Math.max(1, currentZoomFactor - delta));
+        }
+        return currentZoomFactor != pdfView.getZoomFactor();
+    }
+
+    /**
+     * Method to increase the zoom factor for value specified as {@code delta}.
+     *
+     * @param delta zoom factor (increase) delta
+     * @return true if the operation actually did cause a zoom change
+     */
+    private boolean increaseZoomFactor(double delta) {
+        final PDFView pdfView = getSkinnable();
+        final double currentZoomFactor = pdfView.getZoomFactor();
+        if (!pdfView.isShowAll()) {
+            pdfView.setZoomFactor(Math.min(pdfView.getMaxZoomFactor(), currentZoomFactor + delta));
+        }
+        return currentZoomFactor != pdfView.getZoomFactor();
+    }
+
     class PagerService extends Service<Void> {
         private boolean up;
 
@@ -682,12 +713,12 @@ public class PDFViewSkin extends SkinBase<PDFView> {
             wrapper.setMaxHeight(Region.USE_PREF_SIZE);
             wrapper.rotateProperty().bind(pdfView.pageRotationProperty());
             wrapper.addEventHandler(ScrollEvent.SCROLL, evt -> {
-                if (evt.isControlDown()) {
+                if (evt.isShortcutDown()) {
                     if (evt.getDeltaY() > 0) {
-                        pdfView.increaseZoomFactor(0.5);
+                        increaseZoomFactor(0.5);
                     }
                     else {
-                        pdfView.decreaseZoomFactor(0.5);
+                        decreaseZoomFactor(0.5);
                     }
                     evt.consume();
                 }

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/PDFViewSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/PDFViewSkin.java
@@ -681,6 +681,17 @@ public class PDFViewSkin extends SkinBase<PDFView> {
             wrapper.setMaxWidth(Region.USE_PREF_SIZE);
             wrapper.setMaxHeight(Region.USE_PREF_SIZE);
             wrapper.rotateProperty().bind(pdfView.pageRotationProperty());
+            wrapper.addEventHandler(ScrollEvent.SCROLL, evt -> {
+                if (evt.isControlDown()) {
+                    if (evt.getDeltaY() > 0) {
+                        pdfView.increaseZoomFactor(0.5);
+                    }
+                    else {
+                        pdfView.decreaseZoomFactor(0.5);
+                    }
+                    evt.consume();
+                }
+            });
 
             group = new Group(wrapper);
             pane.getChildren().addAll(group);


### PR DESCRIPTION
This PR adds convenient `ctrl+scroll` shortcut to zoom in/out documents.

Currently the effect of `ctr+scroll` is exactly the same as changing a zoom slider. A future improvement might be to actually zoom at the point where mouse pointer is located at the time when zoom action is initiated.

Side note:
That's all I wanted to contribute (for now). Having a new micro release in the near future would be great and thanks for looking after my PRs in timely manner.

