### PR TITLE
Handling StringIndexOutOfBounds exception when pressing backspace after deleting all numbers

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/DigitsField.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/DigitsField.java
@@ -2,6 +2,8 @@ package com.dlsc.gemsfx.skins;
 
 import com.dlsc.gemsfx.TimePicker;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
@@ -139,7 +141,9 @@ public abstract class DigitsField extends TimeField {
     }
 
     private void handleBackspace() {
-        setTypedText(getTypedText().substring(0, getTypedText().length() - 1));
+        if (StringUtils.isNotBlank(getTypedText())) {
+            setTypedText(getTypedText().substring(0, getTypedText().length() - 1));
+        }
     }
 
     private void handleDigit(KeyEvent evt) {


### PR DESCRIPTION
Added check to evaluate `getTextTyped()` text and do nothing when there's nothing else to delete. 
```java
java.lang.StringIndexOutOfBoundsException: begin 0, end -1, length 0
    at java.lang.String.checkBoundsBeginEnd(String.java:3319) ~[?:?]
    at java.lang.String.substring(String.java:1874) ~[?:?]
    at com.dlsc.gemsfx.skins.DigitsField.handleBackspace(DigitsField.java:142) ~[gemsfx-1.28.1.jar:?]
    at com.dlsc.gemsfx.skins.DigitsField.lambda$new$7(DigitsField.java:109) ~[gemsfx-1.28.1.jar:?]
```