### PR TITLE
Use HTTPS repository URL

### DIFF
--- a/gemsfx-demo/pom.xml
+++ b/gemsfx-demo/pom.xml
@@ -41,14 +41,14 @@
 
         <repository>
             <id>jpro - sandec repository</id>
-            <url>http://sandec.bintray.com/repo</url>
+            <url>https://sandec.bintray.com/repo</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>jpro - sandec repository</id>
-            <url>http://sandec.bintray.com/repo</url>
+            <url>https://sandec.bintray.com/repo</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
Running `mvn verify` to build the project using **Maven 3.8.1**, the following error is shown:

```bash
[ERROR] Plugin com.sandec.jpro:jpro-maven-plugin:2020.1.0 or one of its dependencies could not be resolved: Failed to read artifact descriptor for com.sandec.jpro:jpro-maven-plugin:jar:2020.1.0: Could not transfer artifact com.sandec.jpro:jpro-maven-plugin:pom:2020.1.0 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [jpro - sandec repository (http://sandec.bintray.com/repo, default, releases+snapshots)] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginResolutionException
```

The reason is that Maven 3.8.1 now blocks insecure HTTP repository URLs by default (see [release notes of Maven 3.8.1](https://maven.apache.org/docs/3.8.1/release-notes.html)). This PR changes the URL of the affected repository to use the HTTPS URL instead.