### PR TITLE
Update to latest maven compiler plugin, fix release settings.

### DIFF
--- a/gemsfx-demo/pom.xml
+++ b/gemsfx-demo/pom.xml
@@ -74,16 +74,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>com.sandec.jpro</groupId>
                 <artifactId>jpro-maven-plugin</artifactId>
                 <version>2021.2.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <project.github.repository>dlsc-software-consulting-gmbh/GemsFX</project.github.repository>
         <local.repository.path>/tmp/repository</local.repository.path>
         <java.version>11</java.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
         <javafx.version>18-ea+12</javafx.version>
         <ikonli.version>12.3.0</ikonli.version>
         <sonar.projectKey>dlsc-software-consulting-gmbh_GemsFX</sonar.projectKey>
@@ -157,12 +158,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <release>11</release>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
+                <version>3.10.1</version>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
As an answer to your question

https://twitter.com/dlemmermann/status/1509523708569784324?s=20&t=YgHmyeHenrmWE9h7M89qvA

This fixes the issue, I was able to compile with openjdk version "11.0.14.1" 2022-02-08 proper.

I wouldn't use source/target + release together.