### PR TITLE
building attached shaded jar for use with scenebuilder.

### DIFF
--- a/gemsfx/pom.xml
+++ b/gemsfx/pom.xml
@@ -43,6 +43,32 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.4.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.openjfx:*</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <shadedClassifierName>scenebuilder</shadedClassifierName>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>            
         </plugins>
     </build>
     <repositories>


### PR DESCRIPTION
Adding the maven shade plugin. The shade plugin is configured to leave the original GemsFX artifact(jar) in place and will attach an uber-jar with a classifier of "scenebuilder". The uber-jar will follow this naming convention `gemsfx-${project.version}-scenebuilder.jar`. The uber-jar can be loaded into SceneBuilder so that all dependencies are met and the GemsFX components can be used.