### PR TITLE
Fix time picker view initialization

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/TimePickerPopup.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/TimePickerPopup.java
@@ -100,18 +100,24 @@ public class TimePickerPopup extends HBox {
 
         updateLists();
 
-        timePicker.showingProperty().addListener(it -> Platform.runLater(() -> {
-            updateListViewSelection();
-            hourListView.scrollTo(hourListView.getSelectionModel().getSelectedIndex());
-            minuteListView.scrollTo(minuteListView.getSelectionModel().getSelectedIndex());
-            secondListView.scrollTo(secondListView.getSelectionModel().getSelectedIndex());
-            millisecondListView.scrollTo(millisecondListView.getSelectionModel().getSelectedIndex());
-        }));
+        timePicker.showingProperty().addListener(it -> initializePopupView());
 
         updateTimeUnit();
         
         timePicker.formatProperty().addListener(it -> {
             updateTimeUnit();
+        });
+
+        initializePopupView();
+    }
+
+    private void initializePopupView() {
+        Platform.runLater(() -> {
+            updateListViewSelection();
+            hourListView.scrollTo(hourListView.getSelectionModel().getSelectedIndex());
+            minuteListView.scrollTo(minuteListView.getSelectionModel().getSelectedIndex());
+            secondListView.scrollTo(secondListView.getSelectionModel().getSelectedIndex());
+            millisecondListView.scrollTo(millisecondListView.getSelectionModel().getSelectedIndex());
         });
     }
 


### PR DESCRIPTION
The list view number corresponding to the time were not selected when the popup was open for the first time.