### PR TITLE
Some fixes and improvements

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/PhoneNumberFieldSkin2.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/PhoneNumberFieldSkin2.java
@@ -195,7 +195,7 @@ public class PhoneNumberFieldSkin2 extends SkinBase<PhoneNumberField2> {
             int index = -1;
 
             if (item != null && !empty) {
-                setText("(+" + item.phonePrefix() + ") " + new Locale("en", item.iso2Code()).getDisplayCountry());
+                setText("(" + item.phonePrefix() + ") " + new Locale("en", item.iso2Code()).getDisplayCountry());
                 setGraphic(getCountryCodeFlagView(item));
                 index = getSkinnable().getPreferredCountryCodes().indexOf(item);
             } else {


### PR DESCRIPTION
1. Allow entering (+) plus sign in the text field to resolve the country code.
2. Always having the (+) plus sign in the phoneNumberProperty (value) of the control.
3. Passing the entire phoneNumber to the formatter and validator.
4. Allowed removing the country code using the BACK_SPACE key.
5. Added button to clear up the value in the App. 