### PR TITLE
Fix missing focus issue on date range picker;

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/daterange/DateRangePicker.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/daterange/DateRangePicker.java
@@ -1,20 +1,17 @@
 package com.dlsc.gemsfx.daterange;
 
 import com.dlsc.gemsfx.skins.DateRangePickerSkin;
-import javafx.beans.property.*;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
-import javafx.geometry.Side;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import javafx.scene.control.ComboBoxBase;
 import javafx.scene.control.Skin;
 
-import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
-import java.time.temporal.TemporalAdjusters;
-import java.time.temporal.TemporalField;
-import java.time.temporal.WeekFields;
-import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -39,8 +36,6 @@ public class DateRangePicker extends ComboBoxBase<DateRange> {
 
         getStyleClass().add("date-range-picker");
         getStylesheets().add(getUserAgentStylesheet());
-
-        setOnMouseClicked(evt -> requestFocus());
     }
 
     @Override

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/DateRangePickerSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/DateRangePickerSkin.java
@@ -19,22 +19,23 @@ import java.time.format.DateTimeFormatter;
 
 public class DateRangePickerSkin extends CustomComboBoxSkinBase<DateRangePicker> {
 
+    private final DateRangePicker picker;
+    private final DateRangeView view;
     private Label titleLabel;
     private Label rangeLabel;
-
-    private final DateRangeView view;
     private HBox hBox;
 
     public DateRangePickerSkin(DateRangePicker picker) {
         super(picker);
+        this.picker = picker;
 
         view = picker.getDateRangeView();
         view.setFocusTraversable(false); // keep the picker focused / blue border
         view.valueProperty().bindBidirectional(getSkinnable().valueProperty());
         view.setOnClose(this::hide);
 
-        picker.setOnMouseClicked(evt -> picker.show());
-        picker.setOnTouchPressed(evt -> picker.show());
+        picker.setOnMouseClicked(evt -> showPicker());
+        picker.setOnTouchPressed(evt -> showPicker());
 
         InvalidationListener updateLabelsListener = it -> updateLabels();
         picker.valueProperty().addListener(updateLabelsListener);
@@ -45,6 +46,11 @@ public class DateRangePickerSkin extends CustomComboBoxSkinBase<DateRangePicker>
 
         updateView();
         updateLabels();
+    }
+
+    private void showPicker() {
+        picker.requestFocus();
+        picker.show();
     }
 
     @Override


### PR DESCRIPTION
This commit addresses an issue where the DateRangePicker component fails to visibly gain focus after the user interacts with other focusable elements like buttons or input fields. The fix ensures that the DateRangePicker correctly displays the focus indicator, improving accessibility and user experience.
<img width="461" alt="image" src="https://github.com/dlsc-software-consulting-gmbh/GemsFX/assets/75261429/35a5c6a9-371e-4897-8ce5-cf47c7093bba">
