### PR TITLE
Fix missing focus on CalendarPicker

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/CalendarPickerSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/CalendarPickerSkin.java
@@ -34,7 +34,10 @@ public class CalendarPickerSkin extends CustomComboBoxSkinBase<CalendarPicker> {
         StackPane arrowButton = new StackPane(arrow);
         arrowButton.setFocusTraversable(false);
         arrowButton.getStyleClass().add("arrow-button"); // using styles similar to combobox, for consistency
-        arrowButton.setOnMouseClicked(evt -> picker.show());
+        arrowButton.setOnMouseClicked(evt -> {
+            picker.requestFocus();
+            picker.show();
+        });
         HBox.setHgrow(picker.getEditor(), Priority.ALWAYS);
 
         HBox box = new HBox(picker.getEditor(), arrowButton);


### PR DESCRIPTION
This commit resolves an issue where the CalendarPicker component would not visibly gain focus upon clicking the calendar selection button. This behavior differed from the default JavaFX DatePicker, leading to inconsistent user experience.
<img width="324" alt="image" src="https://github.com/dlsc-software-consulting-gmbh/GemsFX/assets/75261429/b51a7388-6818-43b9-bc1e-317e8faa9c9e">
