### PR TITLE
Add Optional Auto-Submit on Blur for SearchField

### DIFF
--- a/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SearchFieldApp.java
+++ b/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SearchFieldApp.java
@@ -74,13 +74,13 @@ public class SearchFieldApp extends Application {
         CheckBox showLeftRightNodes = new CheckBox("Show extra left & right nodes");
         showLeftRightNodes.setSelected(false);
 
-        CheckBox autoSubmitOnBlurBox = new CheckBox("Auto submit on field lost focus.");
-        autoSubmitOnBlurBox.selectedProperty().bindBidirectional(field.autoSubmitOnBlurProperty());
+        CheckBox autoCommitOnFocusLostBox = new CheckBox("Auto commit on field lost focus.");
+        autoCommitOnFocusLostBox.selectedProperty().bindBidirectional(field.autoCommitOnFocusLostProperty());
 
         field.leftProperty().bind(Bindings.createObjectBinding(() -> showLeftRightNodes.isSelected() ? regionLeft : null, showLeftRightNodes.selectedProperty()));
         field.rightProperty().bind(Bindings.createObjectBinding(() -> showLeftRightNodes.isSelected() ? regionRight : null, showLeftRightNodes.selectedProperty()));
 
-        VBox vbox = new VBox(20, createNewItemBox, showPromptText, usePlaceholder, hideWithSingleChoiceBox, showSearchIconBox, showLeftRightNodes,autoSubmitOnBlurBox, hBox, hBox2, field);
+        VBox vbox = new VBox(20, createNewItemBox, showPromptText, usePlaceholder, hideWithSingleChoiceBox, showSearchIconBox, showLeftRightNodes,autoCommitOnFocusLostBox, hBox, hBox2, field);
         vbox.setPadding(new Insets(20));
 
         Scene scene = new Scene(vbox);

--- a/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SearchFieldApp.java
+++ b/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SearchFieldApp.java
@@ -74,10 +74,13 @@ public class SearchFieldApp extends Application {
         CheckBox showLeftRightNodes = new CheckBox("Show extra left & right nodes");
         showLeftRightNodes.setSelected(false);
 
+        CheckBox autoSubmitOnBlurBox = new CheckBox("Auto submit on field lost focus.");
+        autoSubmitOnBlurBox.selectedProperty().bindBidirectional(field.autoSubmitOnBlurProperty());
+
         field.leftProperty().bind(Bindings.createObjectBinding(() -> showLeftRightNodes.isSelected() ? regionLeft : null, showLeftRightNodes.selectedProperty()));
         field.rightProperty().bind(Bindings.createObjectBinding(() -> showLeftRightNodes.isSelected() ? regionRight : null, showLeftRightNodes.selectedProperty()));
 
-        VBox vbox = new VBox(20, createNewItemBox, showPromptText, usePlaceholder, hideWithSingleChoiceBox, showSearchIconBox, showLeftRightNodes, hBox, hBox2, field);
+        VBox vbox = new VBox(20, createNewItemBox, showPromptText, usePlaceholder, hideWithSingleChoiceBox, showSearchIconBox, showLeftRightNodes,autoSubmitOnBlurBox, hBox, hBox2, field);
         vbox.setPadding(new Insets(20));
 
         Scene scene = new Scene(vbox);

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/SearchField.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/SearchField.java
@@ -106,7 +106,7 @@ public class SearchField<T> extends Control {
         setPlaceholder(new Label("No items found"));
 
         editor.focusedProperty().addListener(it -> {
-            if (!isAutoSubmitOnBlur()) {
+            if (!isAutoCommitOnFocusLost()) {
                 if (popup.isShowing()) {
                     popup.hide();
                 }
@@ -877,37 +877,37 @@ public class SearchField<T> extends Control {
         return placeholder == null ? null : placeholder.get();
     }
 
-    private BooleanProperty autoSubmitOnBlur;
+    private BooleanProperty autoCommitOnFocusLost;
 
     /**
-     * Returns the BooleanProperty that indicates if text should auto-submit when the field loses focus.
-     * The property is lazy-initialized and defaults to true, enabling auto-submit by default.
+     * Returns the BooleanProperty that indicates if text should auto-commit when the field loses focus.
+     * The property is lazy-initialized and defaults to true, enabling auto-commit by default.
      *
-     * @return the BooleanProperty for autoSubmitOnBlur.
+     * @return the BooleanProperty for autoCommitOnFocusLost.
      */
-    public final BooleanProperty autoSubmitOnBlurProperty() {
-        if (autoSubmitOnBlur == null) {
-            autoSubmitOnBlur = new SimpleBooleanProperty(this, "autoSubmitOnBlur", true);
+    public final BooleanProperty autoCommitOnFocusLostProperty() {
+        if (autoCommitOnFocusLost == null) {
+            autoCommitOnFocusLost = new SimpleBooleanProperty(this, "autoCommitOnFocusLost", true);
         }
-        return autoSubmitOnBlur;
+        return autoCommitOnFocusLost;
     }
 
     /**
-     * Checks if the auto-submit on blur feature is enabled.
+     * Checks if the auto-commit on focus lost feature is enabled.
      *
-     * @return true if auto-submit on blur is enabled, false otherwise.
+     * @return true if auto-commit on focus lost is enabled, false otherwise.
      */
-    public final boolean isAutoSubmitOnBlur() {
-        return autoSubmitOnBlur == null || autoSubmitOnBlur.get();
+    public final boolean isAutoCommitOnFocusLost() {
+        return autoCommitOnFocusLost == null || autoCommitOnFocusLost.get();
     }
 
     /**
-     * Sets the value of the autoSubmitOnBlur property.
+     * Sets the value of the autoCommitOnFocusLost property.
      *
-     * @param value if true, enables auto-submit on blur; if false, disables it.
+     * @param value if true, enables auto-commit on focus lost; if false, disables it.
      */
-    public final void setAutoSubmitOnBlur(boolean value) {
-        autoSubmitOnBlurProperty().set(value);
+    public final void setAutoCommitOnFocusLost(boolean value) {
+        autoCommitOnFocusLostProperty().set(value);
     }
 
     /**

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/SearchField.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/SearchField.java
@@ -106,6 +106,13 @@ public class SearchField<T> extends Control {
         setPlaceholder(new Label("No items found"));
 
         editor.focusedProperty().addListener(it -> {
+            if (!isAutoSubmitOnBlur()) {
+                if (popup.isShowing()) {
+                    popup.hide();
+                }
+                return;
+            }
+
             if (!editor.isFocused()) {
                 commit();
                 if (getSelectedItem() == null) {
@@ -868,6 +875,39 @@ public class SearchField<T> extends Control {
 
     public final Node getPlaceholder() {
         return placeholder == null ? null : placeholder.get();
+    }
+
+    private BooleanProperty autoSubmitOnBlur;
+
+    /**
+     * Returns the BooleanProperty that indicates if text should auto-submit when the field loses focus.
+     * The property is lazy-initialized and defaults to true, enabling auto-submit by default.
+     *
+     * @return the BooleanProperty for autoSubmitOnBlur.
+     */
+    public final BooleanProperty autoSubmitOnBlurProperty() {
+        if (autoSubmitOnBlur == null) {
+            autoSubmitOnBlur = new SimpleBooleanProperty(this, "autoSubmitOnBlur", true);
+        }
+        return autoSubmitOnBlur;
+    }
+
+    /**
+     * Checks if the auto-submit on blur feature is enabled.
+     *
+     * @return true if auto-submit on blur is enabled, false otherwise.
+     */
+    public final boolean isAutoSubmitOnBlur() {
+        return autoSubmitOnBlur == null || autoSubmitOnBlur.get();
+    }
+
+    /**
+     * Sets the value of the autoSubmitOnBlur property.
+     *
+     * @param value if true, enables auto-submit on blur; if false, disables it.
+     */
+    public final void setAutoSubmitOnBlur(boolean value) {
+        autoSubmitOnBlurProperty().set(value);
     }
 
     /**


### PR DESCRIPTION
Introduced a new boolean property autoSubmitOnBlur to the SearchField component, allowing control over the auto-submit behavior when the field loses focus. This feature is enabled by default to maintain existing functionality. However, it can be disabled for scenarios where auto-submit on blur is not desired, enhancing flexibility and user experience.