### PR TITLE
Disable Animation When Search Icon is Hidden

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/SearchField.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/SearchField.java
@@ -227,7 +227,7 @@ public class SearchField<T> extends Control {
         rotateTransition.setDuration(Duration.millis(500));
 
         searching.addListener(it -> {
-            if (searching.get()) {
+            if (searching.get() && isShowSearchIcon()) {
                 rotateTransition.play();
             } else {
                 rotateTransition.stop();


### PR DESCRIPTION
This update ensures that animations are only played when the search icon is visible. Previously, animations would occur even if the search icon was not displayed, leading to unnecessary processing. This fix aligns the animation behavior with the visibility of the search icon, improving the performance.