### PR TITLE
Feature: Hide Popup When No Choices Are Available

### DIFF
--- a/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SearchFieldApp.java
+++ b/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SearchFieldApp.java
@@ -33,7 +33,7 @@ public class SearchFieldApp extends Application {
 
         CountriesSearchField field = new CountriesSearchField();
         field.getEditor().setPrefColumnCount(30);
-        field.setOnCommit(country-> System.out.println("on commit listener in demo was invoked, country = " + country));
+        field.setOnCommit(country -> System.out.println("on commit listener in demo was invoked, country = " + country));
 
         Region regionLeft = new Region();
         regionLeft.setPrefWidth(30);
@@ -68,6 +68,9 @@ public class SearchFieldApp extends Application {
         CheckBox hideWithSingleChoiceBox = new CheckBox("Hide popup if it has only the currently selected item in it");
         hideWithSingleChoiceBox.selectedProperty().bindBidirectional(field.hidePopupWithSingleChoiceProperty());
 
+        CheckBox hideWithNoChoiceBox = new CheckBox("Hide popup if it has no selectable items in it");
+        hideWithNoChoiceBox.selectedProperty().bindBidirectional(field.hidePopupWithNoChoiceProperty());
+
         CheckBox showSearchIconBox = new CheckBox("Show search icon");
         showSearchIconBox.selectedProperty().bindBidirectional(field.showSearchIconProperty());
 
@@ -80,7 +83,7 @@ public class SearchFieldApp extends Application {
         field.leftProperty().bind(Bindings.createObjectBinding(() -> showLeftRightNodes.isSelected() ? regionLeft : null, showLeftRightNodes.selectedProperty()));
         field.rightProperty().bind(Bindings.createObjectBinding(() -> showLeftRightNodes.isSelected() ? regionRight : null, showLeftRightNodes.selectedProperty()));
 
-        VBox vbox = new VBox(20, createNewItemBox, showPromptText, usePlaceholder, hideWithSingleChoiceBox, showSearchIconBox, showLeftRightNodes,autoCommitOnFocusLostBox, hBox, hBox2, field);
+        VBox vbox = new VBox(20, createNewItemBox, showPromptText, usePlaceholder, hideWithSingleChoiceBox, hideWithNoChoiceBox, showSearchIconBox, showLeftRightNodes, autoCommitOnFocusLostBox, hBox, hBox2, field);
         vbox.setPadding(new Insets(20));
 
         Scene scene = new Scene(vbox);

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/SearchField.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/SearchField.java
@@ -461,6 +461,26 @@ public class SearchField<T> extends Control {
         this.hidePopupWithSingleChoice.set(hidePopupWithSingleChoice);
     }
 
+    private final BooleanProperty hidePopupWithNoChoice = new SimpleBooleanProperty(this, "hidePopupWithNoChoice", false);
+
+    public final boolean isHidePopupWithNoChoice() {
+        return hidePopupWithNoChoice.get();
+    }
+
+    /**
+     * Determines whether to hide the popup window when there are no choices available in the suggestion list.
+     * The default value is "false", indicating that the popup does not hide automatically under this condition.
+     *
+     * @return true if the popup should not be shown when there are no suggestions to display.
+     */
+    public final BooleanProperty hidePopupWithNoChoiceProperty() {
+        return hidePopupWithNoChoice;
+    }
+
+    public final void setHidePopupWithNoChoice(boolean hidePopupWithNoChoice) {
+        this.hidePopupWithNoChoice.set(hidePopupWithNoChoice);
+    }
+
     /**
      * A flag indicating whether the asynchronous search is currently in progress.
      * This flag can be used to animate something that expresses that the search is

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SearchFieldPopup.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SearchFieldPopup.java
@@ -54,7 +54,12 @@ public class SearchFieldPopup<T> extends PopupControl {
 
                 // assuming that we don't have to show it
                 boolean showIt = false;
-                if (searchField.getSuggestions().size() == 1) {
+                int suggestionsItemsSize = searchField.getSuggestions().size();
+                if (suggestionsItemsSize == 0) {
+                    if (!searchField.isHidePopupWithNoChoice()) {
+                        showIt = true;
+                    }
+                } else if (suggestionsItemsSize == 1) {
                     if (!searchField.isHidePopupWithSingleChoice() || !searchField.getMatcher().apply(searchField.getSuggestions().get(0), evt.getText())) {
                         showIt = true;
                     }


### PR DESCRIPTION
## Introduction
This Pull Request introduces the `hidePopupWithNoChoice` functionality to SearchField. It aims to enhance user experience by conditionally hiding popups when there are no choices to display.