### PR TITLE
Refactor BeforeAfterView to remove test code and implement orientation as a styleable attribute.

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/BeforeAfterView.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/BeforeAfterView.java
@@ -12,6 +12,7 @@ import javafx.css.StyleableObjectProperty;
 import javafx.css.StyleableProperty;
 import javafx.css.converter.EnumConverter;
 import javafx.geometry.Orientation;
+import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Control;
 import javafx.scene.control.Label;
@@ -91,7 +92,13 @@ public class BeforeAfterView extends Control {
         this.dividerPosition.set(dividerPosition);
     }
 
-    private final ObjectProperty<Node> before = new SimpleObjectProperty<>(this, "before", new Label("Before"));
+
+    private final ObjectProperty<Node> before = new SimpleObjectProperty<>(this, "before", new Label("Before"){
+        {
+            setPrefSize(600, 400);
+            setStyle("-fx-background-color: red;");
+        }
+    });
 
     public final Node getBefore() {
         return before.get();
@@ -105,7 +112,13 @@ public class BeforeAfterView extends Control {
         this.before.set(before);
     }
 
-    private final ObjectProperty<Node> after = new SimpleObjectProperty<>(this, "after", new Label("After"));
+    private final ObjectProperty<Node> after = new SimpleObjectProperty<>(this, "after", new Label("After"){
+        {
+            setPrefSize(600, 400);
+            setStyle("-fx-background-color: green;");
+            setAlignment(Pos.CENTER_RIGHT);
+        }
+    });
 
     public final Node getAfter() {
         return after.get();


### PR DESCRIPTION
The BeforeAfterView component currently contains some code that was only intended for testing purposes and should be removed to clean up the codebase. Additionally, the existing Orientation property can be replaced with a styleable attribute to enhance flexibility and integration with CSS. - #156 