### PR TITLE
Implement i18n, optimize property initialization, and fix focus loss in InfoCenterView

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/infocenter/InfoCenterPane.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/infocenter/InfoCenterPane.java
@@ -25,6 +25,8 @@ import one.jpro.jproutils.treeshowing.TreeShowing;
  */
 public class InfoCenterPane extends Control {
 
+    private static final Duration DEFAULT_SLIDE_IN_DURATION = Duration.millis(200);
+
     /*
      * The managed info center instance.
      */
@@ -161,7 +163,7 @@ public class InfoCenterPane extends Control {
             }
         };
 
-        TreeShowing.treeShowing(this).addListener((p,o,n) -> {
+        TreeShowing.treeShowing(this).addListener((p, o, n) -> {
             if (n) {
                 timer.start();
             } else {
@@ -231,9 +233,8 @@ public class InfoCenterPane extends Control {
      * A flag that determines if the info center view should automatically disappear again
      * after a certain timeout duration.
      *
-     * @see #autoHideDuration
-     *
      * @return true if the info center hides automatically after a certain period of time
+     * @see #autoHideDuration
      */
     public final BooleanProperty autoHideProperty() {
         return autoHide;
@@ -269,7 +270,7 @@ public class InfoCenterPane extends Control {
 
     // slide in / slide out duration
 
-    private final ObjectProperty<Duration> slideInDuration = new SimpleObjectProperty<>(this, "slideDuration", Duration.millis(200)); //$NON-NLS-1$
+    private ObjectProperty<Duration> slideInDuration; //$NON-NLS-1$
 
     /**
      * The duration used for the "slide in" / "slide out" animation when the info center view
@@ -277,16 +278,19 @@ public class InfoCenterPane extends Control {
      *
      * @return animation duration for the sliding in and out of the info center view
      */
-    public final ObjectProperty<Duration> slideInDuration() {
+    public final ObjectProperty<Duration> slideInDurationProperty() {
+        if (slideInDuration == null) {
+            slideInDuration = new SimpleObjectProperty<>(this, "slideInDuration", DEFAULT_SLIDE_IN_DURATION);
+        }
         return slideInDuration;
     }
 
     public final Duration getSlideInDuration() {
-        return slideInDuration.get();
+        return slideInDuration == null ? DEFAULT_SLIDE_IN_DURATION : slideInDuration.get();
     }
 
     public final void setSlideInDuration(Duration duration) {
-        slideInDuration.set(duration);
+        slideInDurationProperty().set(duration);
     }
 
     private final BooleanProperty showInfoCenter = new SimpleBooleanProperty(this, "showInfoCenter", false);

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/infocenter/NotificationView.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/infocenter/NotificationView.java
@@ -1,6 +1,7 @@
 package com.dlsc.gemsfx.infocenter;
 
 import com.dlsc.gemsfx.infocenter.Notification.OnClickBehaviour;
+import com.dlsc.gemsfx.util.ResourceBundleManager;
 import javafx.animation.FadeTransition;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
@@ -45,6 +46,8 @@ import java.util.Objects;
 public class NotificationView<T, S extends Notification<T>> extends StackPane {
 
     private static final PseudoClass PSEUDO_CLASS_EXPANDED = PseudoClass.getPseudoClass("expanded");
+    private static final DateTimeFormatter SHORT_TIME_FORMATTER = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT);
+
     private final S notification;
     private final ContentPane contentPane;
     private final StackPane stackNotification1;
@@ -211,23 +214,22 @@ public class NotificationView<T, S extends Notification<T>> extends StackPane {
     private static final StringConverter<ZonedDateTime> DEFAULT_TIME_CONVERTER = new StringConverter<>() {
         @Override
         public String toString(ZonedDateTime dateTime) {
-            System.out.println(">> 0");
             if (dateTime != null) {
                 Duration between = Duration.between(dateTime, ZonedDateTime.now());
                 if (between.toDays() == 0) {
                     if (between.toHours() > 2) {
                         return DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).format(dateTime.toLocalTime());
                     } else if (between.toHours() > 0) {
-                        return MessageFormat.format("{0}h ago", between.toHours());
+                        return MessageFormat.format("{0}{1}", between.toHours(), ResourceBundleManager.getString(ResourceBundleManager.Type.NOTIFICATION_VIEW, "time.hours.ago"));
                     } else if (between.toMinutes() > 0) {
-                        return MessageFormat.format("{0}m ago", between.toMinutes());
+                        return MessageFormat.format("{0}{1}", between.toMinutes(), ResourceBundleManager.getString(ResourceBundleManager.Type.NOTIFICATION_VIEW, "time.minutes.ago"));
                     } else {
-                        return "now";
+                        return ResourceBundleManager.getString(ResourceBundleManager.Type.NOTIFICATION_VIEW, "time.now");
                     }
                 } else if (between.toDays() == 1) {
-                    return MessageFormat.format("Yesterday, {0}", DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).format(dateTime.toLocalTime()));
+                    return MessageFormat.format("{0}, {1}", ResourceBundleManager.getString(ResourceBundleManager.Type.NOTIFICATION_VIEW,"time.yesterday"), SHORT_TIME_FORMATTER.format(dateTime.toLocalTime()));
                 } else if (between.toDays() < 7) {
-                    return MessageFormat.format("{0} days ago", between.toDays());
+                    return MessageFormat.format("{0} {1}", between.toDays(), ResourceBundleManager.getString(ResourceBundleManager.Type.NOTIFICATION_VIEW, "time.days.ago"));
                 } else {
                     return DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT).format(dateTime);
                 }
@@ -346,7 +348,7 @@ public class NotificationView<T, S extends Notification<T>> extends StackPane {
             contentProperty().addListener(it -> updateCenterNode(center));
             showContentProperty().addListener(it -> updateCenterNode(center));
 
-            Label clearAllLabel = new Label("Clear All");
+            Label clearAllLabel = new Label(ResourceBundleManager.getString(ResourceBundleManager.Type.NOTIFICATION_VIEW, "group.clear.all"));
             clearAllLabel.getStyleClass().add("clear-all");
             clearAllLabel.setMouseTransparent(true);
 

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/util/ResourceBundleManager.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/util/ResourceBundleManager.java
@@ -1,0 +1,107 @@
+package com.dlsc.gemsfx.util;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * This class provides a centralized mechanism to retrieve localized strings
+ * from property files based on the current locale settings. It caches the resource bundles
+ * to avoid repetitive and unnecessary loading of the properties files.
+ *
+ * <p>Usage involves retrieving strings via base names of the resource bundles
+ * or by using predefined types which represent specific views or components
+ * in the application.</p>
+ */
+public class ResourceBundleManager {
+
+    private static final Logger LOG = Logger.getLogger(ResourceBundleManager.class.getName());
+    private static final Map<String, ResourceBundle> BUNDLES = new ConcurrentHashMap<>();
+    private static Locale currentLocale = Locale.getDefault();
+
+    public enum Type {
+        INFO_CENTER_VIEW("info-center-view"),
+        NOTIFICATION_VIEW("notification-view");
+
+        private final String baseName;
+
+        Type(String baseName) {
+            this.baseName = baseName;
+        }
+
+        public String getBaseName() {
+            return baseName;
+        }
+    }
+
+    private ResourceBundleManager() {
+    }
+
+    /**
+     * Retrieves the resource bundle for the specified base name and the current application locale.
+     * This method will return a cached bundle if it exists, or load a new bundle if it does not.
+     *
+     * @param baseName the base name of the resource bundle.
+     * @return the requested resource bundle.
+     */
+    public static ResourceBundle getBundle(String baseName) {
+        return BUNDLES.computeIfAbsent(key(baseName, currentLocale),
+                k -> ResourceBundle.getBundle(baseName, currentLocale, ResourceBundleManager.class.getClassLoader()));
+    }
+
+    /**
+     * Sets the current locale of the application. If the locale is changed,
+     * the method clears the cache of loaded resource bundles.
+     *
+     * @param locale the new locale to set as the current.
+     */
+    public static void setLocale(Locale locale) {
+        if (!locale.equals(currentLocale)) {
+            currentLocale = locale;
+            // Clear cache as locale has changed
+            BUNDLES.clear();
+        }
+    }
+
+
+    /**
+     *  Generates a unique key based on the base name and locale for caching purposes.
+     */
+    private static String key(String baseName, Locale locale) {
+        return baseName + "_" + locale.toString();
+    }
+
+    /**
+     * Retrieves a localized string from the resource bundle specified by the base name.
+     * If the key is not found, it logs a warning and returns the key itself.
+     *
+     * @param baseName the base name of the resource bundle.
+     * @param key the key for the desired string in the bundle.
+     * @return the localized string.
+     */
+    public static String getString(String baseName, String key) {
+        try {
+            ResourceBundle bundle = getBundle(baseName);
+            return bundle.getString(key);
+        } catch (MissingResourceException ex) {
+            LOG.log(Level.WARNING, "Missing resource key: " + key, ex);
+            return key;
+        }
+    }
+
+    /**
+     * Retrieves a localized string from the resource bundle associated with a given type.
+     *
+     * @param type the type of the resource bundle.
+     * @param key the key for the desired string in the bundle.
+     * @return the localized string.
+     */
+    public static String getString(Type type, String key) {
+        return getString(type.getBaseName(), key);
+    }
+
+}

--- a/gemsfx/src/main/resources/info-center-view.properties
+++ b/gemsfx/src/main/resources/info-center-view.properties
@@ -1,0 +1,9 @@
+group.header.show.all=Show All
+group.header.show.all.tip=Show all notifications of this group in a list
+group.header.show.less=Show Less
+group.header.show.less.tip=Stack the notifications
+group.header.remove.all.tip=Remove all notifications from the group
+group.header.pin.tip=Pin the group at the top
+single.group.header.close=Close Group
+single.group.header.close.tip=Switch back to view with all groups
+single.group.header.remove.all=Remove all notifications

--- a/gemsfx/src/main/resources/info-center-view_zh.properties
+++ b/gemsfx/src/main/resources/info-center-view_zh.properties
@@ -1,0 +1,9 @@
+group.header.show.all=\u5168\u90e8\u663e\u793a
+group.header.show.all.tip=\u5728\u5217\u8868\u4e2d\u663e\u793a\u672c\u7ec4\u5168\u90e8\u901a\u77e5
+group.header.show.less=\u6298\u53e0\u901a\u77e5
+group.header.show.less.tip=\u6536\u8d77\u672c\u7ec4\u901a\u77e5
+group.header.remove.all.tip=\u5220\u9664\u672c\u7ec4\u5168\u90e8\u901a\u77e5
+group.header.pin.tip=\u56fa\u5b9a\u672c\u7ec4\u901a\u77e5\u5230\u9876\u90e8
+single.group.header.close=\u5173\u95ed
+single.group.header.close.tip=\u8fd4\u56de\u67e5\u770b\u6240\u6709\u7ec4\u7684\u901a\u77e5
+single.group.header.remove.all=\u5220\u9664\u672c\u7ec4\u5168\u90e8\u901a\u77e5

--- a/gemsfx/src/main/resources/notification-view.properties
+++ b/gemsfx/src/main/resources/notification-view.properties
@@ -1,0 +1,6 @@
+group.clear.all=Clear All
+time.now=now
+time.hours.ago=h ago
+time.minutes.ago=m ago
+time.yesterday=Yesterday
+time.days.ago=days ago

--- a/gemsfx/src/main/resources/notification-view_zh.properties
+++ b/gemsfx/src/main/resources/notification-view_zh.properties
@@ -1,0 +1,6 @@
+group.clear.all=\u6e05\u7a7a
+time.now=\u73b0\u5728
+time.hours.ago=\u5c0f\u65f6\u524d
+time.minutes.ago=\u5206\u949f\u524d
+time.yesterday=\u6628\u5929
+time.days.ago=\u5929\u524d


### PR DESCRIPTION
Focus Loss on Notification Group Collapse:
Collapsing a notification group within the InfoCenterView results in a loss of focus, causing incorrect scrolling behavior in the notification list.

Lack of Internationalization:
The InfoCenterView contains a significant amount of text that has not been internationalized, potentially limiting its usability in multi-lingual environments.
Unnecessary Immediate Property Initialization:

Many properties in InfoCenterView are currently initialized immediately but are only used for getting values. These properties do not need to be bound and can be initialized lazily on demand to optimize performance and resource usage.
#155
