### PR TITLE
 Fix Issue with Picker Component Closure Behavior

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/ToggleVisibilityComboBoxSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/ToggleVisibilityComboBoxSkin.java
@@ -2,6 +2,8 @@ package com.dlsc.gemsfx.skins;
 
 import javafx.event.Event;
 import javafx.scene.control.ComboBoxBase;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
 
 public abstract class ToggleVisibilityComboBoxSkin<T extends ComboBoxBase> extends CustomComboBoxSkinBase<T> {
@@ -11,6 +13,14 @@ public abstract class ToggleVisibilityComboBoxSkin<T extends ComboBoxBase> exten
 
     public ToggleVisibilityComboBoxSkin(T control) {
         super(control);
+
+        // Pressed the esc key to hide the popup.
+        control.addEventFilter(KeyEvent.KEY_PRESSED, e -> {
+            if (e.getCode() == KeyCode.ESCAPE) {
+                showPopupOnMouseRelease = true;
+                hide();
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
> Currently, when the Picker component is closed using the Esc key, it requires consecutive clicks on the Picker button to display the popup again. 

To address this issue, we need to implement handling for the Esc key press event in the Picker component to ensure consistent behavior.