### PR TITLE
Improvements and Fixes for Notification Component

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/infocenter/NotificationView.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/infocenter/NotificationView.java
@@ -423,7 +423,7 @@ public class NotificationView<T, S extends Notification<T>> extends StackPane {
             if (contentIsExpanded) {
                 if (!center.getChildren().contains(content)) {
                     VBox.setMargin(content, new Insets(5, 0, 0, 0));
-                    center.getChildren().add(content);
+                    center.getChildren().add(2, content);
                 }
             } else {
                 if (content != null) {

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/infocenter/NotificationView.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/infocenter/NotificationView.java
@@ -227,7 +227,7 @@ public class NotificationView<T, S extends Notification<T>> extends StackPane {
                         return ResourceBundleManager.getString(ResourceBundleManager.Type.NOTIFICATION_VIEW, "time.now");
                     }
                 } else if (between.toDays() == 1) {
-                    return MessageFormat.format("{0}, {1}", ResourceBundleManager.getString(ResourceBundleManager.Type.NOTIFICATION_VIEW,"time.yesterday"), SHORT_TIME_FORMATTER.format(dateTime.toLocalTime()));
+                    return MessageFormat.format("{0}, {1}", ResourceBundleManager.getString(ResourceBundleManager.Type.NOTIFICATION_VIEW, "time.yesterday"), SHORT_TIME_FORMATTER.format(dateTime.toLocalTime()));
                 } else if (between.toDays() < 7) {
                     return MessageFormat.format("{0} {1}", between.toDays(), ResourceBundleManager.getString(ResourceBundleManager.Type.NOTIFICATION_VIEW, "time.days.ago"));
                 } else {
@@ -297,7 +297,18 @@ public class NotificationView<T, S extends Notification<T>> extends StackPane {
             titleLabel.getStyleClass().add("title-label");
             HBox.setHgrow(titleLabel, Priority.ALWAYS);
 
-            BooleanBinding showArrowBinding = hoverProperty().and(notification.getGroup().expandedProperty()).and(contentProperty().isNotNull());
+            BooleanBinding showArrowBinding = Bindings.createBooleanBinding(() -> {
+                boolean contentIsNull = getContent() == null;
+                if (contentIsNull || !isHover()) {
+                    return false;
+                }
+
+                if (notification.getGroup().getNotifications().size() == 1) {
+                    return true;
+                }
+
+                return notification.getGroup().isExpanded();
+            }, hoverProperty(), notification.getGroup().expandedProperty(), notification.getGroup().getNotifications(), contentProperty());
 
             timeLabel = new Label();
             timeLabel.setMinWidth(Region.USE_PREF_SIZE);

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/infocenter/NotificationView.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/infocenter/NotificationView.java
@@ -17,6 +17,7 @@ import javafx.css.PseudoClass;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
+import javafx.scene.Parent;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
@@ -36,6 +37,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A view used for visualizing a notification
@@ -84,7 +86,7 @@ public class NotificationView<T, S extends Notification<T>> extends StackPane {
         getChildren().addAll(stackNotification2, stackNotification1, contentPane);
 
         // This is needed. Maybe a bug in the centerProperty() binding inside ContentPane?
-        showContentProperty().addListener(it -> getParent().requestLayout());
+        showContentProperty().addListener(it -> Optional.ofNullable(getParent()).ifPresent(Parent::requestLayout));
 
         MapChangeListener<? super Object, ? super Object> ml = change -> {
             if (change.wasAdded()) {

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/infocenter/NotificationView.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/infocenter/NotificationView.java
@@ -298,8 +298,7 @@ public class NotificationView<T, S extends Notification<T>> extends StackPane {
             HBox.setHgrow(titleLabel, Priority.ALWAYS);
 
             BooleanBinding showArrowBinding = Bindings.createBooleanBinding(() -> {
-                boolean contentIsNull = getContent() == null;
-                if (contentIsNull || !isHover()) {
+                if ((getContent() == null) || !isHover()) {
                     return false;
                 }
 

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/InfoCenterViewSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/InfoCenterViewSkin.java
@@ -1,6 +1,5 @@
 package com.dlsc.gemsfx.skins;
 
-import com.dlsc.gemsfx.binding.AggregatedListBinding;
 import com.dlsc.gemsfx.infocenter.InfoCenterEvent;
 import com.dlsc.gemsfx.infocenter.InfoCenterView;
 import com.dlsc.gemsfx.infocenter.Notification;
@@ -19,7 +18,6 @@ import javafx.beans.Observable;
 import javafx.beans.WeakInvalidationListener;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
-import javafx.beans.binding.ObjectBinding;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleDoubleProperty;
@@ -266,11 +264,7 @@ public class InfoCenterViewSkin extends SkinBase<InfoCenterView> {
 
         getChildren().add(mainPane);
 
-        AggregatedListBinding<NotificationGroup<?, ?>, ? extends Notification<?>, Boolean> emptyBinding = new AggregatedListBinding<>(
-                view.getGroups(),
-                NotificationGroup::getNotifications,
-                stream -> stream.findFirst().isEmpty()
-        );
+        BooleanBinding emptyBinding = Bindings.createBooleanBinding(() -> view.getUnmodifiableNotifications().isEmpty(), view.getUnmodifiableNotifications());
 
         addPlaceholderIfNotNull(view.getPlaceholder(), emptyBinding);
 
@@ -322,7 +316,7 @@ public class InfoCenterViewSkin extends SkinBase<InfoCenterView> {
     }
 
 
-    private void addPlaceholderIfNotNull(Node placeholder, ObjectBinding<Boolean> emptyBing) {
+    private void addPlaceholderIfNotNull(Node placeholder, BooleanBinding emptyBing) {
         if (placeholder != null) {
             placeholder.managedProperty().bind(emptyBing);
             placeholder.visibleProperty().bind(emptyBing);


### PR DESCRIPTION
1. When a Group contains only one notification and the content of this notification is not empty, an arrow icon should be displayed to facilitate users in clicking to view the content. 
2. Refactor layout request to prevent NullPointerException.  Enhance the showContentProperty() listener to use Optional for safe layout request handling. This prevents NullPointerExceptions that occur if the parent is null, which can happen when notifications are expanded by default before their parent container is initialized.
3. Adjust the position of Actions to the bottom of the notification view.