### PR TITLE
Add option to store history on focus loss

### DIFF
--- a/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SearchTextFieldApp.java
+++ b/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SearchTextFieldApp.java
@@ -1,6 +1,5 @@
 package com.dlsc.gemsfx.demo;
 
-import com.dlsc.gemsfx.RemovableListCell;
 import com.dlsc.gemsfx.SearchTextField;
 import javafx.application.Application;
 import javafx.beans.binding.Bindings;
@@ -50,6 +49,11 @@ public class SearchTextFieldApp extends Application {
         field1.addHistoryOnEnterProperty().bind(addHistoryOnActionBox.selectedProperty());
         field2.addHistoryOnEnterProperty().bind(addHistoryOnActionBox.selectedProperty());
 
+        CheckBox addHistoryOnFocusLossBox = new CheckBox("Add History on Focus Loss");
+        addHistoryOnFocusLossBox.setSelected(true);
+        field1.addHistoryOnLostFocusProperty().bind(addHistoryOnFocusLossBox.selectedProperty());
+        field2.addHistoryOnLostFocusProperty().bind(addHistoryOnFocusLossBox.selectedProperty());
+
         Button setHistoryButton = new Button("Set History");
         setHistoryButton.setMaxWidth(Double.MAX_VALUE);
         setHistoryButton.setOnAction(e -> {
@@ -76,7 +80,7 @@ public class SearchTextFieldApp extends Application {
         });
 
         VBox vbox = new VBox(20, new Label("Standard"), field1, new Label("Round"), field2,
-                new Separator(), maxHistorySizeBox, enableHistoryPopupBox, addHistoryOnActionBox,
+                new Separator(), maxHistorySizeBox, enableHistoryPopupBox, addHistoryOnActionBox, addHistoryOnFocusLossBox,
                 setHistoryButton, addHistoryButton, removeStandardHistoryButton, removeRoundHistoryButton, clearButton);
         vbox.setPadding(new Insets(20));
 

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/SearchTextField.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/SearchTextField.java
@@ -56,6 +56,7 @@ public class SearchTextField extends CustomTextField {
     private static final int DEFAULT_MAX_HISTORY_SIZE = 30;
     private static final boolean ENABLE_HISTORY_POPUP = true;
     private static final boolean DEFAULT_ADD_HISTORY_ON_ENTER = true;
+    private static final boolean DEFAULT_ADD_HISTORY_ON_LOST_FOCUS = true;
 
     private static final PseudoClass DISABLED_POPUP_PSEUDO_CLASS = PseudoClass.getPseudoClass("disabled-popup");
     private static final PseudoClass HISTORY_POPUP_SHOWING_PSEUDO_CLASS = PseudoClass.getPseudoClass("history-popup-showing");
@@ -160,7 +161,12 @@ public class SearchTextField extends CustomTextField {
     }
 
     private void addPropertyListeners() {
-        focusedProperty().addListener(it -> hideHistoryPopup());
+        focusedProperty().subscribe(isFocused -> {
+            hideHistoryPopup();
+            if (!isFocused && isAddHistoryOnLostFocus()) {
+                addHistory(getText());
+            }
+        });
 
         maxHistorySizeProperty().addListener(it -> {
             // Check if the max history size is negative. If so, log a warning.
@@ -464,6 +470,28 @@ public class SearchTextField extends CustomTextField {
 
     public final void setPreferences(Preferences preferences) {
         this.preferences.set(preferences);
+    }
+
+    private BooleanProperty addHistoryOnLostFocus;
+
+    /**
+     * Indicates whether the text of the text field should be added to the history when the text field loses focus.
+     *
+     * @return true if the text should be added to the history on lost focus, false otherwise
+     */
+    public final BooleanProperty addHistoryOnLostFocusProperty() {
+        if (addHistoryOnLostFocus == null) {
+            addHistoryOnLostFocus = new SimpleBooleanProperty(this, "addHistoryOnLostFocus", DEFAULT_ADD_HISTORY_ON_LOST_FOCUS);
+        }
+        return addHistoryOnLostFocus;
+    }
+
+    public final boolean isAddHistoryOnLostFocus() {
+        return addHistoryOnLostFocus == null ? DEFAULT_ADD_HISTORY_ON_LOST_FOCUS : addHistoryOnLostFocus.get();
+    }
+
+    public final void setAddHistoryOnLostFocus(boolean addHistoryOnLostFocus) {
+        addHistoryOnLostFocusProperty().set(addHistoryOnLostFocus);
     }
 
     /**


### PR DESCRIPTION
A new option has been implemented in the SearchTextField class to allow the addition of text to history when the text field loses focus. The option is turned on by default but can be customized. The demo application has been updated to include a checkbox to trigger history addition on focus loss.