### PR TITLE
Add dynamic start angle functionality to CircleProgressIndicator

### DIFF
--- a/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SemiCircleProgressIndicatorApp.java
+++ b/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SemiCircleProgressIndicatorApp.java
@@ -1,19 +1,15 @@
 package com.dlsc.gemsfx.demo;
 
-import com.dlsc.gemsfx.CircleProgressIndicator;
+import com.dlsc.gemsfx.SemiCircleProgressIndicator;
 import javafx.application.Application;
 import javafx.application.Platform;
-import javafx.beans.binding.Bindings;
 import javafx.concurrent.Service;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
-import javafx.scene.control.Label;
 import javafx.scene.control.Separator;
-import javafx.scene.control.Slider;
-import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
@@ -24,13 +20,13 @@ import org.kordamp.ikonli.javafx.FontIcon;
 
 import java.util.Objects;
 
-public class CircleProgressIndicatorApp extends Application {
+public class SemiCircleProgressIndicatorApp extends Application {
 
     private StringConverter<Double> customConverter;
 
     @Override
     public void start(Stage primaryStage) {
-        CircleProgressIndicator progressIndicator = new CircleProgressIndicator();
+        SemiCircleProgressIndicator progressIndicator = new SemiCircleProgressIndicator();
         delayAutoUpdateProgress(progressIndicator);
 
         // styles
@@ -40,22 +36,11 @@ public class CircleProgressIndicatorApp extends Application {
         String firstStyle = styles[0];
         // add style
         progressIndicator.getStyleClass().add(firstStyle);
-        styleComboBox.setMaxWidth(Double.MAX_VALUE);
         styleComboBox.setValue(firstStyle);
         styleComboBox.valueProperty().addListener(it -> {
             progressIndicator.getStyleClass().removeAll(styles);
             progressIndicator.getStyleClass().add(styleComboBox.getValue());
         });
-
-        // start Angle
-        Label startAngleLabel = new Label("Start Angle");
-        Slider startAngleSlider = new Slider(0, 360, 90);
-        progressIndicator.startAngleProperty().bind(startAngleSlider.valueProperty());
-        Label startAngleValue = new Label();
-        startAngleValue.setPrefWidth(30);
-        startAngleValue.textProperty().bind(Bindings.format("%.0f", startAngleSlider.valueProperty()));
-        HBox startAngleBox = new HBox(5, startAngleLabel, startAngleSlider, startAngleValue);
-        startAngleBox.setAlignment(Pos.CENTER_LEFT);
 
         // graphic
         FontIcon graphic = new FontIcon();
@@ -76,7 +61,7 @@ public class CircleProgressIndicatorApp extends Application {
         indicatorWrapper.getStyleClass().add("indicator-wrapper");
         VBox.setVgrow(indicatorWrapper, Priority.ALWAYS);
 
-        VBox bottom = new VBox(10, showGraphic, customConverterBox, startAngleBox, styleComboBox);
+        VBox bottom = new VBox(10, styleComboBox, showGraphic, customConverterBox);
         bottom.setAlignment(Pos.CENTER_LEFT);
         bottom.setMaxWidth(Region.USE_PREF_SIZE);
 
@@ -86,14 +71,14 @@ public class CircleProgressIndicatorApp extends Application {
         containerBox.setAlignment(Pos.CENTER);
         containerBox.getChildren().addAll(indicatorWrapper, new Separator(), bottom);
 
-        Scene scene = new Scene(containerBox, 330, 390);
-        scene.getStylesheets().add(Objects.requireNonNull(CircleProgressIndicatorApp.class.getResource("arc-progress-indicator-demo.css")).toExternalForm());
+        Scene scene = new Scene(containerBox, 300, 390);
+        scene.getStylesheets().add(Objects.requireNonNull(SemiCircleProgressIndicatorApp.class.getResource("arc-progress-indicator-demo.css")).toExternalForm());
         primaryStage.setScene(scene);
-        primaryStage.setTitle("CircleProgressIndicator Demo");
+        primaryStage.setTitle("SemiCircleProgressIndicator");
         primaryStage.show();
     }
 
-    private void delayAutoUpdateProgress(CircleProgressIndicator graphicIndicator) {
+    private void delayAutoUpdateProgress(SemiCircleProgressIndicator graphicIndicator) {
         Service<Void> service = new Service<>() {
             @Override
             protected javafx.concurrent.Task<Void> createTask() {

--- a/gemsfx-demo/src/main/resources/com/dlsc/gemsfx/demo/arc-progress-indicator-demo.css
+++ b/gemsfx-demo/src/main/resources/com/dlsc/gemsfx/demo/arc-progress-indicator-demo.css
@@ -1,57 +1,57 @@
-.circle-progress-indicator {
+.arc-progress-indicator {
     /*-fx-font-family: Monospaced;*/
 }
 
-.circle-progress-indicator .progress-label {
+.arc-progress-indicator .progress-label {
     -fx-font-size: 15px;
 }
 
 /** --- icons --- */
-.circle-progress-indicator .progress-label .ikonli-font-icon {
+.arc-progress-indicator .progress-label .ikonli-font-icon {
     -fx-icon-code: mdi-download;
     -fx-icon-size: 16px;
 }
 
-.circle-progress-indicator:indeterminate .progress-label .ikonli-font-icon {
+.arc-progress-indicator:indeterminate .progress-label .ikonli-font-icon {
     -fx-icon-code: mdi-access-point-network;
 }
 
-.circle-progress-indicator:completed .progress-label .ikonli-font-icon {
+.arc-progress-indicator:completed .progress-label .ikonli-font-icon {
     -fx-icon-code: mdi-check-circle-outline;
 }
 
 /* --- bold style --- */
-.circle-progress-indicator.bold-style .track-circle {
+.arc-progress-indicator.bold-style .track-circle {
     -fx-stroke-width: 10px;
     -fx-stroke: #dadada;
 }
 
-.circle-progress-indicator.bold-style .progress-arc {
+.arc-progress-indicator.bold-style .progress-arc {
     -fx-stroke-width: 5px;
     -fx-stroke: #67986e;
 }
 
 /** --- thin style --- */
-.circle-progress-indicator.thin-style .track-circle {
+.arc-progress-indicator.thin-style .track-circle {
     -fx-stroke-width: 1px;
     -fx-stroke: #c9c9c9;
 }
 
-.circle-progress-indicator.thin-style .progress-arc {
+.arc-progress-indicator.thin-style .progress-arc {
     -fx-stroke-width: 1px;
     -fx-stroke: #f87328;
 }
 
 /** --- sector style --- */
-.circle-progress-indicator.sector-style {
-    -fx-arc-type: ROUND;
+.arc-progress-indicator.sector-style {
+    -fx-progress-arc-type: ROUND;
 }
 
-.circle-progress-indicator.sector-style .track-circle {
+.arc-progress-indicator.sector-style .track-circle {
     -fx-stroke-width: 5px;
 }
 
-.circle-progress-indicator.sector-style .progress-arc {
+.arc-progress-indicator.sector-style .progress-arc {
     -fx-fill: #47bce833;
     -fx-stroke-width: 1px;
 }

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/ArcProgressIndicator.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/ArcProgressIndicator.java
@@ -1,0 +1,253 @@
+package com.dlsc.gemsfx;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.css.CssMetaData;
+import javafx.css.Styleable;
+import javafx.css.StyleableObjectProperty;
+import javafx.css.StyleableProperty;
+import javafx.css.converter.EnumConverter;
+import javafx.scene.Node;
+import javafx.scene.control.ProgressIndicator;
+import javafx.scene.shape.ArcType;
+import javafx.util.StringConverter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * ArcProgressIndicator is a visual control used to indicate the progress of a task.
+ * It represents progress in an arc form, with options to show determinate or indeterminate states.
+ * <p>
+ * In a determinate state, the arc fills up based on the progress value, which ranges from 0.0 to 1.0,
+ * where 0.0 indicates no progress and 1.0 indicates completion.
+ * <p>
+ * In an indeterminate state, the arc shows a cyclic animation, indicating that progress is ongoing
+ * but the exact status is unknown. This state is useful for tasks where the progress cannot be determined.
+ * <p>
+ * The control also supports displaying a text or graphic inside the arc to provide additional
+ * information or visual feedback to the user.
+ * <p>
+ * Usage examples include file downloads, file transfers, or any long-running tasks where
+ * visual feedback on progress is beneficial.
+ *
+ * <p>
+ * <b>Pseudo class:</b> Beyond the <b>inherited</b>, <b>indeterminate</b>, and <b>determinate</b> pseudo-classes
+ * from ProgressIndicator, ArcProgressIndicator introduces a <b>completed</b> pseudo-class.
+ * This pseudo-class can be used in CSS to apply custom styles when the progress reaches 1.0 (100%).
+ *
+ * <p>
+ * <b>Tips:</b> If you prefer not to instantiate the animation object during initialization,
+ * pass a 0.0 as the initial progress. This setup indicates no progress but avoids entering
+ * the indeterminate state, which would otherwise instantiate and start the animation.
+ *
+ * <p>Usage examples:
+ * <pre>
+ *     // Initializes with no progress and no animation.
+ *     ArcProgressIndicator progressIndicator = new ArcProgressIndicator(0.0);
+ * </pre>
+ */
+public class ArcProgressIndicator extends ProgressIndicator {
+
+    private static final String DEFAULT_STYLE_CLASS = "arc-progress-indicator";
+    private static final ArcType DEFAULT_PROGRESS_ARC_TYPE = ArcType.OPEN;
+    private static final ArcType DEFAULT_TRACK_ARC_TYPE = ArcType.CHORD;
+
+    private static final StringConverter<Double> DEFAULT_CONVERTER = new StringConverter<>() {
+        @Override
+        public String toString(Double progress) {
+            // indeterminate
+            if (progress == null || progress < 0.0) {
+                return "";
+            }
+            // completed
+            if (progress == 1.0) {
+                return "Completed";
+            }
+            return String.format("%.0f%%", progress * 100);
+        }
+
+        @Override
+        public Double fromString(String string) {
+            return null;
+        }
+    };
+
+    public ArcProgressIndicator() {
+        this(INDETERMINATE_PROGRESS);
+    }
+
+    public ArcProgressIndicator(double progress) {
+        super(progress);
+        getStyleClass().add(DEFAULT_STYLE_CLASS);
+    }
+
+    @Override
+    public String getUserAgentStylesheet() {
+        return Objects.requireNonNull(ArcProgressIndicator.class.getResource("arc-progress-indicator.css")).toExternalForm();
+    }
+
+    private final ObjectProperty<StringConverter<Double>> converter = new SimpleObjectProperty<>(this, "converter", DEFAULT_CONVERTER);
+
+    public final StringConverter<Double> getConverter() {
+        return converter.get();
+    }
+
+    /**
+     * The converter is used to convert the progress value to a string that is displayed
+     *
+     * @return the converter property
+     */
+    public final ObjectProperty<StringConverter<Double>> converterProperty() {
+        return converter;
+    }
+
+    public final void setConverter(StringConverter<Double> converter) {
+        converterProperty().set(converter);
+    }
+
+    private final ObjectProperty<Node> graphic = new SimpleObjectProperty<>(this, "graphic");
+
+    /**
+     * The graphic property is used to display a custom node within the progress indicator.
+     * progress label's graphic property is bound to this property.
+     *
+     * @return the graphic property
+     */
+    public final ObjectProperty<Node> graphicProperty() {
+        return graphic;
+    }
+
+    public final Node getGraphic() {
+        return graphic.get();
+    }
+
+    public final void setGraphic(Node graphic) {
+        graphicProperty().set(graphic);
+    }
+
+    private ObjectProperty<ArcType> progressArcType;
+
+    /**
+     * The arc type property defines the type of the arc that is used to display the progress.
+     *
+     * @return the arc type property for the progress
+     */
+    public final ObjectProperty<ArcType> progressArcTypeProperty() {
+        if (progressArcType == null) {
+            progressArcType = new StyleableObjectProperty<>(DEFAULT_PROGRESS_ARC_TYPE) {
+                @Override
+                public Object getBean() {
+                    return this;
+                }
+
+                @Override
+                public String getName() {
+                    return "progressArcType";
+                }
+
+                @Override
+                public CssMetaData<? extends Styleable, ArcType> getCssMetaData() {
+                    return StyleableProperties.PROGRESS_ARC_TYPE;
+                }
+            };
+        }
+        return progressArcType;
+    }
+
+    public final ArcType getProgressArcType() {
+        return progressArcType == null ? DEFAULT_PROGRESS_ARC_TYPE : progressArcType.get();
+    }
+
+    public final void setProgressArcType(ArcType progressArcType) {
+        progressArcTypeProperty().set(progressArcType);
+    }
+
+    private ObjectProperty<ArcType> trackArcType;
+
+    /**
+     * The arc type property defines the type of the arc that is used to display the track.
+     *
+     * @return the arc type property for the track
+     */
+    public final ObjectProperty<ArcType> trackArcTypeProperty() {
+        if (trackArcType == null) {
+            trackArcType = new StyleableObjectProperty<>(DEFAULT_TRACK_ARC_TYPE) {
+                @Override
+                public Object getBean() {
+                    return this;
+                }
+
+                @Override
+                public String getName() {
+                    return "trackArcType";
+                }
+
+                @Override
+                public CssMetaData<? extends Styleable, ArcType> getCssMetaData() {
+                    return StyleableProperties.TRACK_ARC_TYPE;
+                }
+            };
+        }
+        return trackArcType;
+    }
+
+    public final ArcType getTrackArcType() {
+        return trackArcType == null ? DEFAULT_TRACK_ARC_TYPE : trackArcType.get();
+    }
+
+    public final void setTrackArcType(ArcType trackArcType) {
+        trackArcTypeProperty().set(trackArcType);
+    }
+
+    private static class StyleableProperties {
+
+        private static final CssMetaData<ArcProgressIndicator, ArcType> PROGRESS_ARC_TYPE = new CssMetaData<>(
+                "-fx-progress-arc-type", new EnumConverter<>(ArcType.class), DEFAULT_PROGRESS_ARC_TYPE) {
+
+            @Override
+            public StyleableProperty<ArcType> getStyleableProperty(ArcProgressIndicator control) {
+                return (StyleableProperty<ArcType>) control.progressArcTypeProperty();
+            }
+
+            @Override
+            public boolean isSettable(ArcProgressIndicator control) {
+                return control.progressArcType == null || !control.progressArcType.isBound();
+            }
+        };
+
+        private static final CssMetaData<ArcProgressIndicator, ArcType> TRACK_ARC_TYPE = new CssMetaData<>(
+                "-fx-track-arc-type", new EnumConverter<>(ArcType.class), DEFAULT_TRACK_ARC_TYPE) {
+
+            @Override
+            public StyleableProperty<ArcType> getStyleableProperty(ArcProgressIndicator control) {
+                return (StyleableProperty<ArcType>) control.trackArcTypeProperty();
+            }
+
+            @Override
+            public boolean isSettable(ArcProgressIndicator control) {
+                return control.trackArcType == null || !control.trackArcType.isBound();
+            }
+        };
+
+        private static final List<CssMetaData<? extends Styleable, ?>> STYLEABLES;
+
+        static {
+            final List<CssMetaData<? extends Styleable, ?>> styleables = new ArrayList<>(ProgressIndicator.getClassCssMetaData());
+            Collections.addAll(styleables, PROGRESS_ARC_TYPE, TRACK_ARC_TYPE);
+            STYLEABLES = Collections.unmodifiableList(styleables);
+        }
+    }
+
+    @Override
+    protected List<CssMetaData<? extends Styleable, ?>> getControlCssMetaData() {
+        return getClassCssMetaData();
+    }
+
+    public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
+        return ArcProgressIndicator.StyleableProperties.STYLEABLES;
+    }
+
+}

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/CircleProgressIndicator.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/CircleProgressIndicator.java
@@ -1,7 +1,9 @@
 package com.dlsc.gemsfx;
 
 import com.dlsc.gemsfx.skins.CircleProgressIndicatorSkin;
+import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.css.CssMetaData;
 import javafx.css.Styleable;
@@ -55,6 +57,7 @@ import java.util.Objects;
 public class CircleProgressIndicator extends ProgressIndicator {
 
     private static final String DEFAULT_STYLE_CLASS = "circle-progress-indicator";
+    private static final double DEFAULT_START_ANGLE = 90.0;
     private static final ArcType DEFAULT_ARC_TYPE = ArcType.OPEN;
     private static final StringConverter<Double> DEFAULT_CONVERTER = new StringConverter<>() {
         @Override
@@ -133,6 +136,29 @@ public class CircleProgressIndicator extends ProgressIndicator {
 
     public final void setGraphic(Node graphic) {
         graphicProperty().set(graphic);
+    }
+
+    private DoubleProperty startAngle;
+
+    /**
+     * The start angle property defines the starting angle of the arc that is used to display the progress.
+     * The default value is 90 degrees, which corresponds to the top of the circle.
+     *
+     * @return the start angle property
+     */
+    public final DoubleProperty startAngleProperty() {
+        if (startAngle == null) {
+            startAngle = new SimpleDoubleProperty(this, "startAngle", DEFAULT_START_ANGLE);
+        }
+        return startAngle;
+    }
+
+    public final double getStartAngle() {
+        return startAngle == null ? DEFAULT_START_ANGLE : startAngle.get();
+    }
+
+    public final void setStartAngle(double startAngle) {
+        startAngleProperty().set(startAngle);
     }
 
     private ObjectProperty<ArcType> arcType;

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/CircleProgressIndicator.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/CircleProgressIndicator.java
@@ -2,25 +2,8 @@ package com.dlsc.gemsfx;
 
 import com.dlsc.gemsfx.skins.CircleProgressIndicatorSkin;
 import javafx.beans.property.DoubleProperty;
-import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleDoubleProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.css.CssMetaData;
-import javafx.css.Styleable;
-import javafx.css.StyleableObjectProperty;
-import javafx.css.StyleableProperty;
-import javafx.css.converter.EnumConverter;
-import javafx.scene.Node;
-import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.Skin;
-import javafx.scene.shape.ArcType;
-import javafx.util.StringConverter;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-
 
 /**
  * CircleProgressIndicator is a visual control used to indicate the progress of a task.
@@ -37,6 +20,10 @@ import java.util.Objects;
  * <p>
  * Usage examples include file downloads, file transfers, or any long-running tasks where
  * visual feedback on progress is beneficial.
+ * <p>
+ * The CircleProgressIndicator extends ArcProgressIndicator and adds a start angle property
+ * that defines the starting angle of the arc used to display the progress. The default start angle is 90 degrees,
+ * which corresponds to the top of the circle.
  *
  * <p>
  * <b>Pseudo class:</b> Beyond the <b>inherited</b> , <b>indeterminate</b> and determinate pseudo-classes
@@ -54,30 +41,10 @@ import java.util.Objects;
  *     CircleProgressIndicator progressIndicator = new CircleProgressIndicator(0.0);
  * </pre>
  */
-public class CircleProgressIndicator extends ProgressIndicator {
+public class CircleProgressIndicator extends ArcProgressIndicator {
 
     private static final String DEFAULT_STYLE_CLASS = "circle-progress-indicator";
     private static final double DEFAULT_START_ANGLE = 90.0;
-    private static final ArcType DEFAULT_ARC_TYPE = ArcType.OPEN;
-    private static final StringConverter<Double> DEFAULT_CONVERTER = new StringConverter<>() {
-        @Override
-        public String toString(Double progress) {
-            // indeterminate
-            if (progress == null || progress < 0.0) {
-                return "";
-            }
-            // completed
-            if (progress == 1.0) {
-                return "Completed";
-            }
-            return String.format("%.0f%%", progress * 100);
-        }
-
-        @Override
-        public Double fromString(String string) {
-            return null;
-        }
-    };
 
     public CircleProgressIndicator() {
         this(INDETERMINATE_PROGRESS);
@@ -92,50 +59,6 @@ public class CircleProgressIndicator extends ProgressIndicator {
     @Override
     protected Skin<?> createDefaultSkin() {
         return new CircleProgressIndicatorSkin(this);
-    }
-
-    @Override
-    public String getUserAgentStylesheet() {
-        return Objects.requireNonNull(CircleProgressIndicator.class.getResource("circle-progress-indicator.css")).toExternalForm();
-    }
-
-    private final ObjectProperty<StringConverter<Double>> converter = new SimpleObjectProperty<>(this, "converter", DEFAULT_CONVERTER);
-
-    public final StringConverter<Double> getConverter() {
-        return converter.get();
-    }
-
-    /**
-     * The converter is used to convert the progress value to a string that is displayed
-     *
-     * @return the converter property
-     */
-    public final ObjectProperty<StringConverter<Double>> converterProperty() {
-        return converter;
-    }
-
-    public final void setConverter(StringConverter<Double> converter) {
-        converterProperty().set(converter);
-    }
-
-    private final ObjectProperty<Node> graphic = new SimpleObjectProperty<>(this, "graphic");
-
-    /**
-     * The graphic property is used to display a custom node within the progress indicator.
-     * progress label's graphic property is bound to this property.
-     *
-     * @return the graphic property
-     */
-    public final ObjectProperty<Node> graphicProperty() {
-        return graphic;
-    }
-
-    public final Node getGraphic() {
-        return graphic.get();
-    }
-
-    public final void setGraphic(Node graphic) {
-        graphicProperty().set(graphic);
     }
 
     private DoubleProperty startAngle;
@@ -161,74 +84,4 @@ public class CircleProgressIndicator extends ProgressIndicator {
         startAngleProperty().set(startAngle);
     }
 
-    private ObjectProperty<ArcType> arcType;
-
-    /**
-     * The arc type property defines the type of the arc that is used to display the progress.
-     *
-     * @return the arc type property
-     */
-    public final ObjectProperty<ArcType> arcTypeProperty() {
-        if (arcType == null) {
-            arcType = new StyleableObjectProperty<>(DEFAULT_ARC_TYPE) {
-                @Override
-                public Object getBean() {
-                    return this;
-                }
-
-                @Override
-                public String getName() {
-                    return "arcType";
-                }
-
-                @Override
-                public CssMetaData<? extends Styleable, ArcType> getCssMetaData() {
-                    return StyleableProperties.ARC_TYPE;
-                }
-            };
-        }
-        return arcType;
-    }
-
-    public final ArcType getArcType() {
-        return arcType == null ? DEFAULT_ARC_TYPE : arcType.get();
-    }
-
-    public final void setArcType(ArcType arcType) {
-        arcTypeProperty().set(arcType);
-    }
-
-    private static class StyleableProperties {
-
-        private static final CssMetaData<CircleProgressIndicator, ArcType> ARC_TYPE = new CssMetaData<>(
-                "-fx-arc-type", new EnumConverter<>(ArcType.class), DEFAULT_ARC_TYPE) {
-
-            @Override
-            public StyleableProperty<ArcType> getStyleableProperty(CircleProgressIndicator control) {
-                return (StyleableProperty<ArcType>) control.arcTypeProperty();
-            }
-
-            @Override
-            public boolean isSettable(CircleProgressIndicator control) {
-                return control.arcType == null || !control.arcType.isBound();
-            }
-        };
-
-        private static final List<CssMetaData<? extends Styleable, ?>> STYLEABLES;
-
-        static {
-            final List<CssMetaData<? extends Styleable, ?>> styleables = new ArrayList<>(ProgressIndicator.getClassCssMetaData());
-            styleables.add(ARC_TYPE);
-            STYLEABLES = Collections.unmodifiableList(styleables);
-        }
-    }
-
-    @Override
-    protected List<CssMetaData<? extends Styleable, ?>> getControlCssMetaData() {
-        return getClassCssMetaData();
-    }
-
-    public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
-        return CircleProgressIndicator.StyleableProperties.STYLEABLES;
-    }
 }

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/SemiCircleProgressIndicator.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/SemiCircleProgressIndicator.java
@@ -1,0 +1,57 @@
+package com.dlsc.gemsfx;
+
+import com.dlsc.gemsfx.skins.SemiCircleProgressIndicatorSkin;
+import javafx.scene.control.Skin;
+
+/**
+ * SemiCircleProgressIndicator is a visual control used to indicate the progress of a task.
+ * It represents progress in a semi-circular form, with options to show determinate or indeterminate states.
+ * <p>
+ * In a determinate state, the semi-circle fills up based on the progress value, which ranges from 0.0 to 1.0,
+ * where 0.0 indicates no progress and 1.0 indicates completion.
+ * <p>
+ * In an indeterminate state, the semi-circle shows a cyclic animation, indicating that progress is ongoing
+ * but the exact status is unknown. This state is useful for tasks where the progress cannot be determined.
+ * <p>
+ * The control also supports displaying a text or graphic inside the semi-circle to provide additional
+ * information or visual feedback to the user.
+ * <p>
+ * Usage examples include file downloads, file transfers, or any long-running tasks where
+ * visual feedback on progress is beneficial.
+ *
+ * <p>
+ * <b>Pseudo class:</b> Beyond the <b>inherited</b>, <b>indeterminate</b>, and <b>determinate</b> pseudo-classes
+ * from ProgressIndicator, SemiCircleProgressIndicator introduces a <b>completed</b> pseudo-class.
+ * This pseudo-class can be used in CSS to apply custom styles when the progress reaches 1.0 (100%).
+ *
+ * <p>
+ * <b>Tips:</b> If you prefer not to instantiate the animation object during initialization,
+ * pass a 0.0 as the initial progress. This setup indicates no progress but avoids entering
+ * the indeterminate state, which would otherwise instantiate and start the animation.
+ *
+ * <p>Usage examples:
+ * <pre>
+ *     // Initializes with no progress and no animation.
+ *     SemiCircleProgressIndicator progressIndicator = new SemiCircleProgressIndicator(0.0);
+ * </pre>
+ */
+public class SemiCircleProgressIndicator extends ArcProgressIndicator {
+
+    private static final String DEFAULT_STYLE_CLASS = "semi-circle-progress-indicator";
+
+    public SemiCircleProgressIndicator() {
+        this(INDETERMINATE_PROGRESS);
+    }
+
+    public SemiCircleProgressIndicator(double progress) {
+        super(progress);
+        getStyleClass().add(DEFAULT_STYLE_CLASS);
+        setMinSize(26, 26);
+    }
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        return new SemiCircleProgressIndicatorSkin(this);
+    }
+
+}

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/ArcProgressIndicatorSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/ArcProgressIndicatorSkin.java
@@ -1,0 +1,213 @@
+package com.dlsc.gemsfx.skins;
+
+import com.dlsc.gemsfx.ArcProgressIndicator;
+import javafx.animation.Animation;
+import javafx.animation.Timeline;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.DoubleBinding;
+import javafx.css.PseudoClass;
+import javafx.scene.control.Label;
+import javafx.scene.control.SkinBase;
+import javafx.scene.shape.Arc;
+import javafx.scene.transform.Rotate;
+import javafx.util.StringConverter;
+
+public abstract class ArcProgressIndicatorSkin<T extends ArcProgressIndicator> extends SkinBase<T> {
+
+    private static final PseudoClass PSEUDO_CLASS_COMPLETED = PseudoClass.getPseudoClass("completed");
+    protected final Label progressLabel = new Label();
+    protected final Arc trackArc = new Arc();
+    protected final Arc progressArc = new Arc();
+    protected final Rotate rotate = new Rotate();
+    protected DoubleBinding radiusBinding;
+    protected Timeline indeterminateAnimation;
+
+    public ArcProgressIndicatorSkin(T control) {
+        super(control);
+
+        initComponents();
+
+        registerListener();
+
+        updateProgress();
+    }
+
+    protected void initComponents() {
+        T control = getSkinnable();
+
+        // init the progress label
+        progressLabel.getStyleClass().add("progress-label");
+        progressLabel.setWrapText(true);
+        progressLabel.graphicProperty().bind(control.graphicProperty());
+        progressLabel.textProperty().bind(Bindings.createStringBinding(() -> {
+            double progress = control.getProgress();
+            StringConverter<Double> converter = control.getConverter();
+            return converter == null ? null : converter.toString(progress);
+        }, control.progressProperty(), control.converterProperty()));
+        progressLabel.managedProperty().bind(progressLabel.visibleProperty());
+        progressLabel.visibleProperty().bind(control.graphicProperty().isNotNull().or(progressLabel.textProperty().isNotEmpty()));
+
+        // calculate the radius of the circle based on the size of the control
+        radiusBinding = getRadiusBinding(control);
+
+        // init the track arc
+        trackArc.getStyleClass().add("track-circle");
+        trackArc.setManaged(false);
+        trackArc.radiusXProperty().bind(radiusBinding);
+        trackArc.radiusYProperty().bind(radiusBinding);
+        trackArc.typeProperty().bind(control.trackArcTypeProperty());
+
+        // init the progress arc
+        progressArc.getStyleClass().add("progress-arc");
+        progressArc.setManaged(false);
+        progressArc.setLength(360);
+        progressArc.radiusXProperty().bind(radiusBinding);
+        progressArc.radiusYProperty().bind(radiusBinding);
+        progressArc.typeProperty().bind(control.progressArcTypeProperty());
+
+        getChildren().addAll(trackArc, progressArc, progressLabel);
+    }
+
+    private void registerListener() {
+        T control = getSkinnable();
+
+        registerChangeListener(control.progressProperty(), it -> updateProgress());
+
+        registerChangeListener(control.visibleProperty(), it -> {
+            if (control.isVisible() && control.getProgress() < 0.0) {
+                playAnimation();
+            } else {
+                pauseAnimation();
+            }
+        });
+    }
+
+    private void updateProgress() {
+        T control = getSkinnable();
+        double progress = control.getProgress();
+        control.pseudoClassStateChanged(PSEUDO_CLASS_COMPLETED, progress == 1.0);
+
+        if (progress < 0.0) {
+            if (control.isVisible()) {
+                playAnimation();
+            } else {
+                pauseAnimation();
+            }
+        } else {
+            stopAnimation();
+            progressArc.setLength(getProgressMaxLength() * progress);
+        }
+    }
+
+    protected void stopAnimation() {
+        progressArc.getTransforms().remove(rotate);
+        if (animationIsRunning()) {
+            indeterminateAnimation.stop();
+        }
+    }
+
+    private void pauseAnimation() {
+        if (animationIsRunning()) {
+            indeterminateAnimation.pause();
+        }
+    }
+
+    private void playAnimation() {
+        if (indeterminateAnimation == null) {
+            indeterminateAnimation = initIndeterminateAnimation();
+        }
+
+        if (indeterminateAnimation.getStatus() != Animation.Status.RUNNING) {
+            if (!progressArc.getTransforms().contains(rotate)) {
+                progressArc.getTransforms().add(rotate);
+            }
+            indeterminateAnimation.play();
+        }
+    }
+
+    private boolean animationIsRunning() {
+        return indeterminateAnimation != null && indeterminateAnimation.getStatus() == Animation.Status.RUNNING;
+    }
+
+    @Override
+    protected void layoutChildren(double contentX, double contentY, double contentWidth, double contentHeight) {
+        double arcCenterX = computeAcrCenterX(contentX, contentWidth);
+        double arcCenterY = computeArcCenterY(contentY, contentHeight);
+
+        // set the pivot point for the rotation
+        rotate.setPivotX(arcCenterX - progressArc.getLayoutX());
+        rotate.setPivotY(arcCenterY - progressArc.getLayoutY());
+
+        // layout the arcs
+        trackArc.setCenterX(arcCenterX);
+        trackArc.setCenterY(arcCenterY);
+        progressArc.setCenterX(arcCenterX);
+        progressArc.setCenterY(arcCenterY);
+        trackArc.resize(contentWidth, contentHeight);
+        progressArc.resize(contentWidth, contentHeight);
+
+        // layout the progress label
+        double maxStrokeWidth = Math.max(trackArc.getStrokeWidth(), progressArc.getStrokeWidth());
+        double diameter = (radiusBinding.get() - maxStrokeWidth) * 2;
+
+        double labelMaxWidth = computeLabelWidth(diameter);
+        double labelMaxHeight = computeLabelHeight(diameter);
+
+        progressLabel.setMaxWidth(labelMaxWidth);
+        progressLabel.setMaxHeight(labelMaxHeight);
+        progressLabel.setPrefWidth(labelMaxWidth);
+        progressLabel.setPrefHeight(labelMaxHeight);
+
+        double labelWidth = Math.min(progressLabel.prefWidth(diameter), diameter);
+        double labelHeight = Math.min(progressLabel.prefHeight(labelWidth), diameter);
+
+        double labelX = computeLabelX(arcCenterX, labelWidth);
+        double labelY = computeLabelY(arcCenterY, labelHeight);
+
+        progressLabel.resizeRelocate(labelX, labelY, labelWidth, labelHeight);
+    }
+
+    protected double computeLabelWidth(double diameter) {
+        return diameter;
+    }
+
+    protected double computeAcrCenterX(double contentX, double contentWidth) {
+        return contentX + contentWidth / 2;
+    }
+
+    protected double computeLabelX(double arcCenterX, double labelWidth) {
+        return arcCenterX - (labelWidth / 2);
+    }
+
+    /**
+     * Returns the height of the label.
+     */
+    protected abstract double computeLabelHeight(double diameter);
+
+    /**
+     * Returns the y-coordinate of the center of the progress arc / track arc.
+     */
+    protected abstract double computeArcCenterY(double contentY, double contentHeight);
+
+
+    /**
+     * Returns the y-coordinate of the label.
+     */
+    protected abstract double computeLabelY(double arcCenterY, double labelHeight);
+
+    /**
+     * Initializes the animation that is used when the progress is indeterminate.
+     */
+    protected abstract Timeline initIndeterminateAnimation();
+
+    /**
+     * Returns a binding that calculates the radius of the circle based on the size of the control.
+     */
+    protected abstract DoubleBinding getRadiusBinding(T control);
+
+    /**
+     * Returns the maximum length of the progress arc.
+     */
+    protected abstract double getProgressMaxLength();
+
+}

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/CircleProgressIndicatorSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/CircleProgressIndicatorSkin.java
@@ -61,7 +61,7 @@ public class CircleProgressIndicatorSkin extends SkinBase<CircleProgressIndicato
         // init the progress arc
         progressArc.getStyleClass().add("progress-arc");
         progressArc.setManaged(false);
-        progressArc.setStartAngle(90);
+        progressArc.startAngleProperty().bind(control.startAngleProperty());
         progressArc.setLength(360);
         progressArc.radiusXProperty().bind(radiusBinding);
         progressArc.radiusYProperty().bind(radiusBinding);

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SemiCircleProgressIndicatorSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SemiCircleProgressIndicatorSkin.java
@@ -1,6 +1,6 @@
 package com.dlsc.gemsfx.skins;
 
-import com.dlsc.gemsfx.CircleProgressIndicator;
+import com.dlsc.gemsfx.SemiCircleProgressIndicator;
 import javafx.animation.Animation;
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
@@ -10,9 +10,9 @@ import javafx.beans.binding.DoubleBinding;
 import javafx.geometry.Insets;
 import javafx.util.Duration;
 
-public class CircleProgressIndicatorSkin extends ArcProgressIndicatorSkin<CircleProgressIndicator> {
+public class SemiCircleProgressIndicatorSkin extends ArcProgressIndicatorSkin<SemiCircleProgressIndicator> {
 
-    public CircleProgressIndicatorSkin(CircleProgressIndicator control) {
+    public SemiCircleProgressIndicatorSkin(SemiCircleProgressIndicator control) {
         super(control);
     }
 
@@ -20,57 +20,59 @@ public class CircleProgressIndicatorSkin extends ArcProgressIndicatorSkin<Circle
     protected void initComponents() {
         super.initComponents();
 
-        trackArc.setLength(360);
-        progressArc.startAngleProperty().bind(getSkinnable().startAngleProperty());
+        trackArc.setStartAngle(0);
+        trackArc.setLength(180);
     }
 
     @Override
     protected double getProgressMaxLength() {
-        return -360;
+        return -180;
+    }
+
+    protected void stopAnimation() {
+        super.stopAnimation();
+        progressArc.setStartAngle(180);
     }
 
     @Override
     protected double computeLabelHeight(double diameter) {
-        return diameter;
+        return diameter / 2;
     }
 
-    @Override
     protected Timeline initIndeterminateAnimation() {
         Timeline timeline = new Timeline(
                 new KeyFrame(Duration.ZERO,
-                        new KeyValue(rotate.angleProperty(), 0),
-                        new KeyValue(progressArc.lengthProperty(), 45)),
+                        new KeyValue(progressArc.startAngleProperty(), 180),
+                        new KeyValue(progressArc.lengthProperty(), 0)),
                 new KeyFrame(Duration.seconds(0.75),
-                        new KeyValue(rotate.angleProperty(), 180),
-                        new KeyValue(progressArc.lengthProperty(), 180)),
+                        new KeyValue(progressArc.startAngleProperty(), 90),
+                        new KeyValue(progressArc.lengthProperty(), -60)),
                 new KeyFrame(Duration.seconds(1.5),
-                        new KeyValue(rotate.angleProperty(), 360),
-                        new KeyValue(progressArc.lengthProperty(), 45))
+                        new KeyValue(progressArc.startAngleProperty(), 0),
+                        new KeyValue(progressArc.lengthProperty(), 0))
         );
         timeline.setCycleCount(Animation.INDEFINITE);
         return timeline;
     }
 
     @Override
-    protected DoubleBinding getRadiusBinding(CircleProgressIndicator control) {
+    protected DoubleBinding getRadiusBinding(SemiCircleProgressIndicator control) {
         return Bindings.createDoubleBinding(() -> {
             Insets insets = control.getInsets() != null ? control.getInsets() : Insets.EMPTY;
             double totalHorInset = insets.getLeft() + insets.getRight();
             double totalVerInset = insets.getTop() + insets.getBottom();
-            double maxInset = Math.max(totalHorInset, totalVerInset);
             double maxRadius = Math.max(trackArc.getStrokeWidth(), progressArc.getStrokeWidth());
-            return (Math.min(control.getWidth(), control.getHeight()) - maxInset - maxRadius) / 2;
+            return (Math.min(control.getWidth() - totalHorInset - maxRadius, (control.getHeight() - totalVerInset - maxRadius) * 2)) / 2;
         }, control.widthProperty(), control.heightProperty(), control.insetsProperty(), trackArc.strokeWidthProperty(), progressArc.strokeWidthProperty());
     }
 
     @Override
     protected double computeArcCenterY(double contentY, double contentHeight) {
-        return contentY + contentHeight / 2;
+        return contentY + contentHeight / 2 + radiusBinding.get() / 2;
     }
 
-    @Override
-    protected double computeLabelY(double arcCenterY, double labelHeight) {
-        return arcCenterY - (labelHeight / 2);
+    protected double computeLabelY(double centerY, double labelHeight) {
+        return centerY - labelHeight;
     }
 
 }

--- a/gemsfx/src/main/resources/com/dlsc/gemsfx/arc-progress-indicator.css
+++ b/gemsfx/src/main/resources/com/dlsc/gemsfx/arc-progress-indicator.css
@@ -1,19 +1,19 @@
-.circle-progress-indicator {
+.arc-progress-indicator {
 }
 
-.circle-progress-indicator .track-circle {
+.arc-progress-indicator .track-circle {
     -fx-stroke-width: 3px;
     -fx-stroke: -fx-box-border;
     -fx-fill: transparent;
 }
 
-.circle-progress-indicator .progress-arc {
+.arc-progress-indicator .progress-arc {
     -fx-stroke-width: 3px;
     -fx-stroke: -fx-accent;
     -fx-fill: transparent;
 }
 
-.circle-progress-indicator .progress-label {
+.arc-progress-indicator .progress-label {
     -fx-text-alignment: center;
     -fx-alignment: center;
 }


### PR DESCRIPTION
The update made to the CircleProgressIndicator and CircleProgressIndicatorSkin allows the start angle of the progress arc to be dynamically changed. This is done by binding a new startAngle property to the existing progressArc's startAngle property. The start angle of the progress arc can be customized using the setStartAngle method, which will update the visually displayed progress.

Add SemiCircleProgressIndicator
<img width="281" alt="image" src="https://github.com/dlsc-software-consulting-gmbh/GemsFX/assets/75261429/2a7dd379-1a77-4b01-b187-ba28ae887110">
