### PR TITLE
Update mouse event handling and exception throwing in UIUtil

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/EnhancedPasswordField.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/EnhancedPasswordField.java
@@ -2,7 +2,6 @@ package com.dlsc.gemsfx;
 
 import com.dlsc.gemsfx.skins.EnhancedPasswordFieldSkin;
 import com.dlsc.gemsfx.util.EchoCharConverter;
-import com.dlsc.gemsfx.util.UIUtil;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -15,6 +14,7 @@ import javafx.css.StyleableProperty;
 import javafx.scene.Node;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.Skin;
+import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
@@ -75,7 +75,7 @@ public class EnhancedPasswordField extends PasswordField {
         StackPane rightWrapper = new StackPane(rightIcon);
         rightWrapper.getStyleClass().add("right-icon-wrapper");
         rightWrapper.addEventHandler(MouseEvent.MOUSE_PRESSED, event -> {
-            if (UIUtil.clickOnNode(event)) {
+            if (event.getButton() == MouseButton.PRIMARY) {
                 setShowPassword(!isShowPassword());
                 event.consume();
             }

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/EnhancedPasswordField.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/EnhancedPasswordField.java
@@ -2,6 +2,7 @@ package com.dlsc.gemsfx;
 
 import com.dlsc.gemsfx.skins.EnhancedPasswordFieldSkin;
 import com.dlsc.gemsfx.util.EchoCharConverter;
+import com.dlsc.gemsfx.util.UIUtil;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -14,7 +15,6 @@ import javafx.css.StyleableProperty;
 import javafx.scene.Node;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.Skin;
-import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
@@ -74,8 +74,8 @@ public class EnhancedPasswordField extends PasswordField {
 
         StackPane rightWrapper = new StackPane(rightIcon);
         rightWrapper.getStyleClass().add("right-icon-wrapper");
-        rightWrapper.addEventHandler(MouseEvent.MOUSE_PRESSED, event -> {
-            if (event.getButton() == MouseButton.PRIMARY) {
+        rightWrapper.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> {
+            if (UIUtil.clickOnNode(event)) {
                 setShowPassword(!isShowPassword());
                 event.consume();
             }

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/EnhancedPasswordField.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/EnhancedPasswordField.java
@@ -75,7 +75,7 @@ public class EnhancedPasswordField extends PasswordField {
         StackPane rightWrapper = new StackPane(rightIcon);
         rightWrapper.getStyleClass().add("right-icon-wrapper");
         rightWrapper.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> {
-            if (UIUtil.clickOnNode(event)) {
+            if (UIUtil.isClickOnNode(event)) {
                 setShowPassword(!isShowPassword());
                 event.consume();
             }

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/util/UIUtil.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/util/UIUtil.java
@@ -207,8 +207,8 @@ public class UIUtil {
      * @return {@code true} if the event is a single stable primary button click, {@code false} otherwise.
      * @throws NullPointerException if the event is null.
      */
-    public static boolean clickOnNode(MouseEvent event) {
-        return clickOnNode(event, false);
+    public static boolean isClickOnNode(MouseEvent event) {
+        return isClickOnNode(event, false);
     }
 
     /**
@@ -228,7 +228,7 @@ public class UIUtil {
      *
      * @throws IllegalArgumentException if the event is not a mouse clicked event.
      */
-    public static boolean clickOnNode(MouseEvent event, boolean isSingleClick) {
+    public static boolean isClickOnNode(MouseEvent event, boolean isSingleClick) {
         if (event.getEventType() != MouseEvent.MOUSE_CLICKED) {
             throw new IllegalArgumentException("The event must be a mouse clicked event.");
             // return false;

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/util/UIUtil.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/util/UIUtil.java
@@ -212,7 +212,7 @@ public class UIUtil {
     }
 
     /**
-     * Determines if the given mouse event is a primary button click
+     * Determines if the given mouse clicked event is a primary button click
      * that hasn't moved since it was pressed.
      *
      * <p>This method checks if the mouse event satisfies the following conditions:
@@ -222,12 +222,17 @@ public class UIUtil {
      *   <li>If {@code isSingleClick} is {@code true}, the event must be a single click.</li>
      * </ul>
      *
-     * @param event        The mouse event to check. Must not be null.
+     * @param event The mouse event to check. Must not be null.
      * @param isSingleClick {@code true} if the event must be a single click, {@code false} otherwise.
      * @return {@code true} if the event is a stable primary button click, {@code false} otherwise.
-     * @throws NullPointerException if the event is null.
+     *
+     * @throws IllegalArgumentException if the event is not a mouse clicked event.
      */
     public static boolean clickOnNode(MouseEvent event, boolean isSingleClick) {
+        if (event.getEventType() != MouseEvent.MOUSE_CLICKED) {
+            throw new IllegalArgumentException("The event must be a mouse clicked event.");
+            // return false;
+        }
         return event.getButton() == MouseButton.PRIMARY && event.isStillSincePress() && (!isSingleClick || event.getClickCount() == 1);
     }
 


### PR DESCRIPTION
Updated the clickOnNode method in UIUtil.java to be more specific in handling mouse events. Now, it throws IllegalArgumentException if the event is not a mouse clicked event. Also, refactored the usage of the clickOnNode method in EnhancedPasswordField.java to directly check for primary button click.