### PR TITLE
Update avatar default size in AvatarView

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/AvatarView.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/AvatarView.java
@@ -54,7 +54,7 @@ public class AvatarView extends Control {
     private static final String DEFAULT_STYLE_CLASS = "avatar-view";
     private static final ClipType DEFAULT_CLIP_TYPE = ClipType.SQUARE;
     private static final double DEFAULT_ROUND_SIZE = 10;
-    private static final double DEFAULT_SIZE = 50;
+    private static final double DEFAULT_SIZE = 150;
 
     public AvatarView() {
         getStyleClass().add(DEFAULT_STYLE_CLASS);
@@ -67,7 +67,6 @@ public class AvatarView extends Control {
                 int index = number.intValue() % getNumberOfStyles();
                 getStyleClass().add("style" + index);
             }
-            System.out.println(getStyleClass());
         });
 
         prefWidthProperty().bind(sizeProperty());

--- a/gemsfx/src/main/resources/com/dlsc/gemsfx/avatar-view.css
+++ b/gemsfx/src/main/resources/com/dlsc/gemsfx/avatar-view.css
@@ -1,7 +1,6 @@
 .avatar-view {
     -fx-font-size: 21px;
     -fx-font-weight: bold;
-    -fx-avatar-size: 150px;
 }
 
 .avatar-view .icon-wrapper {


### PR DESCRIPTION
The default avatar size has been increased to 150 in AvatarView.java, creating a more noticeable and prominent avatar display. The size attribute has been removed from the avatar-view.css as it's no longer necessary.