### PR TITLE
Add ability to reset CalendarPicker value to null

### DIFF
--- a/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/CalendarPickerApp.java
+++ b/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/CalendarPickerApp.java
@@ -61,7 +61,10 @@ public class CalendarPickerApp extends Application {
         HBox buttonDisplayBox = new HBox(10, buttonDisplayLabel, buttonDisplayComboBox);
         buttonDisplayBox.setAlignment(Pos.CENTER_LEFT);
 
-        VBox vBox = new VBox(10, popupButtons, calendarPicker, valueLabel, editable, disable, disabledWeekendBox, showTodayButton, buttonDisplayBox);
+        Button clearDateButton = new Button("Clear Date");
+        clearDateButton.setOnAction(evt -> calendarPicker.setValue(null));
+
+        VBox vBox = new VBox(10, popupButtons, calendarPicker, valueLabel, editable, disable, disabledWeekendBox, showTodayButton, clearDateButton, buttonDisplayBox);
         vBox.setAlignment(Pos.TOP_LEFT);
         vBox.setPadding(new Insets(20));
 

--- a/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/CalendarPickerApp.java
+++ b/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/CalendarPickerApp.java
@@ -26,7 +26,7 @@ public class CalendarPickerApp extends Application {
         calendarPicker.setValue(LocalDate.now());
 
         Label valueLabel = new Label();
-        valueLabel.textProperty().bind(Bindings.createStringBinding(() -> calendarPicker.getConverter().toString(calendarPicker.getValue()), calendarPicker.valueProperty()));
+        valueLabel.textProperty().bind(Bindings.createStringBinding(() -> calendarPicker.getValue() == null ? "No Date Selected" : calendarPicker.getConverter().toString(calendarPicker.getValue()), calendarPicker.valueProperty()));
 
         CheckBox editable = new CheckBox("Editable");
         editable.selectedProperty().bindBidirectional(calendarPicker.editableProperty());
@@ -64,7 +64,7 @@ public class CalendarPickerApp extends Application {
         Button clearDateButton = new Button("Clear Date");
         clearDateButton.setOnAction(evt -> calendarPicker.setValue(null));
 
-        VBox vBox = new VBox(10, popupButtons, calendarPicker, valueLabel, editable, disable, disabledWeekendBox, showTodayButton, clearDateButton, buttonDisplayBox);
+        VBox vBox = new VBox(10, popupButtons, calendarPicker, valueLabel, clearDateButton, editable, disable, disabledWeekendBox, showTodayButton, buttonDisplayBox);
         vBox.setAlignment(Pos.TOP_LEFT);
         vBox.setPadding(new Insets(20));
 

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/CalendarPickerSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/CalendarPickerSkin.java
@@ -30,7 +30,8 @@ public class CalendarPickerSkin extends ToggleVisibilityComboBoxSkin<CalendarPic
 
         picker.valueProperty().addListener(it -> {
             if (view != null) {
-                view.setYearMonth(YearMonth.from(picker.getValue()));
+                LocalDate date = picker.getValue();
+                view.setYearMonth(date == null ? YearMonth.now() : YearMonth.from(date));
             }
         });
 


### PR DESCRIPTION
- Allow the CalendarPicker to reset its value to null, enabling the user to indicate no date selection.
- #196 