### PR TITLE
Fix index out-of-bounds in TextViewSkin

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/TextView.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/TextView.java
@@ -6,7 +6,6 @@ import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
-import javafx.beans.value.WritableValue;
 import javafx.collections.MapChangeListener;
 import javafx.css.CssMetaData;
 import javafx.css.Styleable;
@@ -18,16 +17,10 @@ import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Control;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.Skin;
-import javafx.scene.control.SkinBase;
-import javafx.scene.control.TextInputControl;
-import javafx.scene.control.skin.TextInputControlSkin;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
-import javafx.scene.input.KeyCodeCombination;
-import javafx.scene.input.KeyEvent;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.Paint;
-import javafx.scene.text.TextFlow;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -331,7 +324,7 @@ public class TextView extends Control {
         private static final List<CssMetaData<? extends Styleable, ?>> STYLEABLES;
 
         static {
-            final List<CssMetaData<? extends Styleable, ?>> styleables = new ArrayList<>();
+            final List<CssMetaData<? extends Styleable, ?>> styleables = new ArrayList<>(Control.getClassCssMetaData());
             styleables.add(HIGHLIGHT_FILL);
             styleables.add(HIGHLIGHT_STROKE);
             styleables.add(HIGHLIGHT_TEXT_FILL);

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/TextViewSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/TextViewSkin.java
@@ -1,7 +1,6 @@
 package com.dlsc.gemsfx.skins;
 
 import com.dlsc.gemsfx.TextView;
-import javafx.beans.InvalidationListener;
 import javafx.geometry.Point2D;
 import javafx.scene.Cursor;
 import javafx.scene.Node;
@@ -173,6 +172,9 @@ public class TextViewSkin extends SkinBase<TextView> {
         private void selectWord(HitInfo hit) {
             int charIndex = hit.getCharIndex();
             StringBuilder string = getTextFlowContentAsString();
+            if (isInvalidIndex(string, charIndex)) {
+                return;
+            }
 
             int startIndex = -1;
             int endIndex = -1;
@@ -204,6 +206,9 @@ public class TextViewSkin extends SkinBase<TextView> {
         private void selectParagraph(HitInfo hit) {
             int charIndex = hit.getCharIndex();
             StringBuilder string = getTextFlowContentAsString();
+            if (isInvalidIndex(string, charIndex)) {
+                return;
+            }
 
             int startIndex = -1;
             int endIndex = -1;
@@ -273,6 +278,10 @@ public class TextViewSkin extends SkinBase<TextView> {
             text.setSelectionStart(selectionStartPos);
             text.setSelectionEnd(selectionEndPos);
             wrappingPath.getElements().clear();
+        }
+
+        private boolean isInvalidIndex(StringBuilder string, int charIndex) {
+            return string.isEmpty() || charIndex < 0 || charIndex >= string.length();
         }
     }
 }


### PR DESCRIPTION
1. Add Control.getClassCssMetaData() to STYLEABLES; Remove unused imports from TextView.

2. Add checks for invalid character indices in selectWord and selectParagraph methods. Implement isInvalidIndex to ensure indices are within bounds to prevent errors.