### PR TITLE
Refactor method name for clarity

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/daterange/DateRangeView.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/daterange/DateRangeView.java
@@ -47,7 +47,7 @@ public class DateRangeView extends Control {
         endCalendarView = getEndCalendarView();
         endCalendarView.setSelectionModel(selectionModel);
 
-        DateRangePreset todayRange = createTodayRange();
+        DateRangePreset todayRange = createTodayRangePreset();
         getPresets().addAll(todayRange, createYesterdayPreset(), createThisWeekPreset(), createThisMonthPreset(), createLastMonthPreset());
         setValue(todayRange.getDateRangeSupplier().get());
     }
@@ -320,7 +320,7 @@ public class DateRangeView extends Control {
         return presets;
     }
 
-    private DateRangePreset createTodayRange() {
+    private DateRangePreset createTodayRangePreset() {
         return new DateRangePreset("Today", () -> new DateRange("Today", LocalDate.now()));
     }
 


### PR DESCRIPTION
Changed method name from createTodayRange to createTodayRangePreset for improved readability and consistency with other similar methods. This enhances code maintainability and aligns with naming conventions across the project.