### PR TITLE
Add pseudo-classes to CalendarView header

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/CalendarViewSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/CalendarViewSkin.java
@@ -254,8 +254,7 @@ public class CalendarViewSkin extends SkinBase<CalendarView> {
         Spacer rightSpacer = new Spacer();
         rightSpacer.getStyleClass().add("right");
 
-        updateHeader(header, previousArrowButton, leftSpacer, yearSpinnerBox, rightSpacer, nextMonthArrowButton);
-        view.headerLayoutProperty().addListener(it -> updateHeader(header, previousArrowButton, leftSpacer, yearSpinnerBox, rightSpacer, nextMonthArrowButton));
+        view.headerLayoutProperty().subscribe(headerLayout -> updateHeader(header, previousArrowButton, leftSpacer, yearSpinnerBox, rightSpacer, nextMonthArrowButton));
 
         InvalidationListener updateViewListener = evt -> updateView();
         view.yearMonthProperty().addListener(evt -> {

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/CalendarViewSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/CalendarViewSkin.java
@@ -30,6 +30,7 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.WeakChangeListener;
+import javafx.css.PseudoClass;
 import javafx.geometry.HPos;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
@@ -78,6 +79,10 @@ public class CalendarViewSkin extends SkinBase<CalendarView> {
     private static final String RANGE_END_DATE = "range-end";
     private static final String RANGE_DATE = "range-date";
     private static final String DROPDOWN = "dropdown";
+
+    private static final PseudoClass HEADER_LEFT_PSEUDO_CLASS = PseudoClass.getPseudoClass("left");
+    private static final PseudoClass HEADER_CENTER_PSEUDO_CLASS = PseudoClass.getPseudoClass("center");
+    private static final PseudoClass HEADER_RIGHT_PSEUDO_CLASS = PseudoClass.getPseudoClass("right");
 
     private final Label monthLabel;
 
@@ -353,15 +358,22 @@ public class CalendarViewSkin extends SkinBase<CalendarView> {
     }
 
     private void updateHeader(HBox header, StackPane previousArrowButton, Spacer leftSpacer, VBox yearSpinnerBox, Spacer rightSpacer, StackPane nextMonthArrowButton) {
+        header.pseudoClassStateChanged(HEADER_LEFT_PSEUDO_CLASS, false);
+        header.pseudoClassStateChanged(HEADER_CENTER_PSEUDO_CLASS, false);
+        header.pseudoClassStateChanged(HEADER_RIGHT_PSEUDO_CLASS, false);
+
         switch (getSkinnable().getHeaderLayout()) {
             case CENTER:
                 header.getChildren().setAll(previousArrowButton, leftSpacer, monthLabel, yearLabel, yearSpinnerBox, rightSpacer, nextMonthArrowButton);
+                header.pseudoClassStateChanged(HEADER_CENTER_PSEUDO_CLASS, true);
                 break;
             case LEFT:
                 header.getChildren().setAll(monthLabel, yearLabel, yearSpinnerBox, rightSpacer, previousArrowButton, nextMonthArrowButton);
+                header.pseudoClassStateChanged(HEADER_LEFT_PSEUDO_CLASS, true);
                 break;
             case RIGHT:
                 header.getChildren().setAll(previousArrowButton, nextMonthArrowButton, leftSpacer, monthLabel, yearLabel);
+                header.pseudoClassStateChanged(HEADER_RIGHT_PSEUDO_CLASS, true);
                 break;
         }
     }


### PR DESCRIPTION
Implemented pseudo-classes for the CalendarView header to indicate its layout position (left, center, or right). This change enhances the visual differentiation of header layouts by applying corresponding CSS styles.