### PR TITLE
Implement Pseudo-Class Style for Selected Month in YearMonthView Component

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/YearMonthViewSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/YearMonthViewSkin.java
@@ -30,7 +30,7 @@ public class YearMonthViewSkin extends SkinBase<YearMonthView> {
     private static final PseudoClass CURRENT_MONTH_PSEUDO_CLASS = PseudoClass.getPseudoClass("current");
 
     private final ObjectProperty<Integer> year = new SimpleObjectProperty<>(this, "year");
-    private boolean updatingMonthBox = false;
+    private boolean updatingMonthBox;
 
     public YearMonthViewSkin(YearMonthView control) {
         super(control);

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/YearMonthViewSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/YearMonthViewSkin.java
@@ -64,18 +64,7 @@ public class YearMonthViewSkin extends SkinBase<YearMonthView> {
 
         GridPane gridPane = new GridPane();
         gridPane.getStyleClass().add("grid-pane");
-        gridPane.add(new MonthBox(Month.JANUARY, control), 0, 0);
-        gridPane.add(new MonthBox(Month.FEBRUARY, control), 2, 0);
-        gridPane.add(new MonthBox(Month.MARCH, control), 0, 1);
-        gridPane.add(new MonthBox(Month.APRIL, control), 2, 1);
-        gridPane.add(new MonthBox(Month.MAY, control), 0, 2);
-        gridPane.add(new MonthBox(Month.JUNE, control), 2, 2);
-        gridPane.add(new MonthBox(Month.JULY, control), 0, 3);
-        gridPane.add(new MonthBox(Month.AUGUST, control), 2, 3);
-        gridPane.add(new MonthBox(Month.SEPTEMBER, control), 0, 4);
-        gridPane.add(new MonthBox(Month.OCTOBER, control), 2, 4);
-        gridPane.add(new MonthBox(Month.NOVEMBER, control), 0, 5);
-        gridPane.add(new MonthBox(Month.DECEMBER, control), 2, 5);
+        addMonthBoxToGridPane(gridPane, control);
 
         Region divider = new Region();
         divider.getStyleClass().add("divider");
@@ -129,6 +118,14 @@ public class YearMonthViewSkin extends SkinBase<YearMonthView> {
                 updateMonthBoxes(control.getValue(), gridPane);
             }
         });
+    }
+
+    private void addMonthBoxToGridPane(GridPane gridPane, YearMonthView control) {
+        for (Month month : Month.values()) {
+            int columnIndex = (month.getValue() % 2 == 0) ? 2 : 0;
+            int rowIndex = (month.getValue() - 1) / 2;
+            gridPane.add(new MonthBox(month, control), columnIndex, rowIndex);
+        }
     }
 
     /**

--- a/gemsfx/src/main/resources/com/dlsc/gemsfx/year-month-view.css
+++ b/gemsfx/src/main/resources/com/dlsc/gemsfx/year-month-view.css
@@ -17,10 +17,15 @@
     -fx-cursor: hand;
 }
 
-.year-month-view > .container > .grid-pane .month-box .selection-indicator {
+.year-month-view > .container > .grid-pane .month-box > .indicator {
+    visibility: hidden;
     -fx-pref-height: 2px;
     -fx-background-color: -fx-text-background-color;
     -fx-background-insets: 0px -2px 0px -2px;
+}
+
+.year-month-view > .container > .grid-pane .month-box:selected > .indicator {
+    visibility: visible;
 }
 
 .year-month-view > .container > .grid-pane .divider {


### PR DESCRIPTION
 Currently, the YearMonthView component lacks the capability to apply distinct styles to the selected month. To enhance visual feedback and user interaction, it is proposed to implement a pseudo-class style specifically for the selected month. This addition will allow for easy customization of the appearance of the selected month, making it visually distinguishable from others. For example, the selected month could have a different border color, border style, or font style compared to other months.