### PR TITLE
Fix issues with popup visibility in SelectionBox: handling early show/hide calls and property cleanup

### DIFF
--- a/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SelectionBoxApp.java
+++ b/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SelectionBoxApp.java
@@ -26,6 +26,8 @@ public class SelectionBoxApp extends Application {
 
     @Override
     public void start(Stage primaryStage) throws Exception {
+        selectionBox.show();
+
         SplitPane splitPane = new SplitPane();
         splitPane.setDividerPositions(0.7);
         splitPane.getItems().addAll(createControl(), getControlPanel());
@@ -40,6 +42,7 @@ public class SelectionBoxApp extends Application {
     private Region createControl() {
         selectionBox.setPrefWidth(220);
         selectionBox.getItems().addAll("Item 1", "Item 2", "Item 3", "Option A", "Option B", "Option C", "Option D");
+        selectionBox.getSelectionModel().selectFirst();
         // selectionBox.setItemConverter(new SimpleStringConverter<>(s -> ">>" +s));
 
         StackPane wrapper = new StackPane(selectionBox);
@@ -48,6 +51,10 @@ public class SelectionBoxApp extends Application {
     }
 
     private Node getControlPanel() {
+        // show popup button
+        Button showButton = new Button("Show Popup");
+        showButton.setOnAction(e -> selectionBox.show());
+
         // selection mode
         ComboBox<SelectionMode> selectionModeComboBox = new ComboBox<>();
         selectionModeComboBox.getItems().addAll(SelectionMode.SINGLE, SelectionMode.MULTIPLE);
@@ -204,6 +211,7 @@ public class SelectionBoxApp extends Application {
 
         return new SimpleControlPane(
                 "SelectionBox",
+                new SimpleControlPane.ControlItem("Show Popup", showButton),
                 new SimpleControlPane.ControlItem("Selection Mode", selectionModeComboBox),
                 new SimpleControlPane.ControlItem("Show Extra Buttons", visibleExtraButtonsCheckBox),
                 new SimpleControlPane.ControlItem("Change Extra Buttons", changeExtraButtonsButton),

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SelectionBoxSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SelectionBoxSkin.java
@@ -3,6 +3,7 @@ package com.dlsc.gemsfx.skins;
 import com.dlsc.gemsfx.CustomPopupControl;
 import com.dlsc.gemsfx.SelectionBox;
 import com.dlsc.gemsfx.util.UIUtil;
+import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
@@ -49,6 +50,7 @@ public class SelectionBoxSkin<T> extends SkinBase<SelectionBox<T>> {
     private static final String UPDATE_POPUP_CONTENT = "updatePopupContent";
     private static final String UPDATE_SELECTION_IN_POPUP = "updateSelectionInPopup";
     private static final String UPDATE_EXTRA_BUTTONS_POSITION = "updateExtraButtonsPosition";
+    private static final String SHOW_POPUP_PROPERTY = "showPopup";
 
     private final SelectionBox<T> control;
 
@@ -96,6 +98,16 @@ public class SelectionBoxSkin<T> extends SkinBase<SelectionBox<T>> {
         addListenerToControl();
 
         getChildren().addAll(displayLabel, arrowButton);
+
+        // Check during skin initialization if the popup should be displayed
+        if (control.getProperties().containsKey(SHOW_POPUP_PROPERTY)) {
+            if (Boolean.TRUE.equals(control.getProperties().get(SHOW_POPUP_PROPERTY))) {
+                Platform.runLater(this::showPopup);
+            } else {
+                hidePopup();
+            }
+            control.getProperties().remove(SHOW_POPUP_PROPERTY);
+        }
     }
 
     private void addListenerToControl() {
@@ -150,12 +162,13 @@ public class SelectionBoxSkin<T> extends SkinBase<SelectionBox<T>> {
 
         control.getProperties().addListener((MapChangeListener<Object, Object>) change -> {
             if (change.wasAdded()) {
-                if (change.getKey().equals("showPopup")) {
+                if (change.getKey().equals(SHOW_POPUP_PROPERTY)) {
                     if (Boolean.TRUE.equals(change.getValueAdded())) {
                         showPopup();
                     } else {
                         hidePopup();
                     }
+                    control.getProperties().remove(SHOW_POPUP_PROPERTY);
                 }
             }
         });


### PR DESCRIPTION
This PR fixes two issues in the SelectionBox component related to the popup visibility control:

Fixed the issue where calling show() or hide() before the skin initialization would not properly display the popup. Now the popup behavior works as expected, even when these methods are invoked prior to skin setup.

Resolved the problem where the code previously forgot to remove the communication key in the properties after calling show() or hide(). This key is now properly cleaned up post-action to prevent unwanted behavior.
