### PR TITLE
Fix clipping issue in YearViewSkin header

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/YearViewSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/YearViewSkin.java
@@ -91,7 +91,7 @@ public class YearViewSkin extends SkinBase<YearView> {
         Rectangle clip = new Rectangle();
         clip.widthProperty().bind(yearView.widthProperty());
         clip.heightProperty().bind(yearView.heightProperty());
-        yearView.setClip(clip);
+        header.setClip(clip);
 
         InvalidationListener buildGridListener = obs -> buildGrid();
         yearView.valueProperty().addListener(buildGridListener);


### PR DESCRIPTION
**Description**: This PR addresses an issue where the YearView component was clipped (setClip) to limit the shadow effect only to the bottom of the header. This approach prevented us from adding a shadow effect to the entire YearView component, which is needed to visually distinguish it from the background when used as a popup in the `YearPicker`.

**Changes**:

Adjusted clipping to apply only to the header section of YearView, allowing the component to display a shadow.

**Issue Fixed**: This PR fixes the clipping issue in YearView that previously restricted adding shadows to the entire component.