### PR TITLE
Enforce DATE_RANGE mode in DateRangeView selection model.

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/daterange/DateRangeView.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/daterange/DateRangeView.java
@@ -40,6 +40,11 @@ public class DateRangeView extends Control {
 
         selectionModel = new SelectionModel();
         selectionModel.setSelectionMode(SelectionModel.SelectionMode.DATE_RANGE);
+        selectionModel.selectionModeProperty().addListener(it -> {
+            if (selectionModel.getSelectionMode() != SelectionModel.SelectionMode.DATE_RANGE) {
+                throw new UnsupportedOperationException("SINGLE_DATE and MULTIPLE_DATES modes are not supported");
+            }
+        });
 
         startCalendarView = getStartCalendarView();
         startCalendarView.setSelectionModel(selectionModel);


### PR DESCRIPTION
Added a listener to ensure only DATE_RANGE mode is supported in the selection model. Throwing an exception for unsupported modes to prevent invalid configurations and potential misuse.