### PR TITLE
feat(selection-box): wrap options in ScrollPane and add directional extra nodes

### DIFF
--- a/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SelectionBoxApp.java
+++ b/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SelectionBoxApp.java
@@ -10,6 +10,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.SplitPane;
 import javafx.scene.layout.Region;
@@ -23,10 +24,26 @@ import java.util.List;
 public class SelectionBoxApp extends Application {
 
     private final SelectionBox<String> selectionBox = new SelectionBox<>();
+    private final StackPane topNode = new StackPane();
+    private final StackPane bottomNode = new StackPane();
+    private final StackPane leftNode = new StackPane();
+    private final StackPane rightNode = new StackPane();
 
     @Override
     public void start(Stage primaryStage) throws Exception {
         selectionBox.show();
+
+        topNode.setStyle("-fx-background-color: lightblue;-fx-padding: 10;");
+        topNode.getChildren().add(new Label("Top"));
+
+        bottomNode.getChildren().add(new Label("Bottom"));
+        bottomNode.setStyle("-fx-background-color: lightcoral;-fx-padding: 10;");
+
+        leftNode.getChildren().add(new Label("Left"));
+        leftNode.setStyle("-fx-background-color: lightgreen;-fx-padding: 10;");
+
+        rightNode.getChildren().add(new Label("Right"));
+        rightNode.setStyle("-fx-background-color: lightyellow;-fx-padding: 10;");
 
         SplitPane splitPane = new SplitPane();
         splitPane.setDividerPositions(0.7);
@@ -60,9 +77,23 @@ public class SelectionBoxApp extends Application {
         selectionModeComboBox.getItems().addAll(SelectionMode.SINGLE, SelectionMode.MULTIPLE);
         selectionModeComboBox.valueProperty().bindBidirectional(selectionBox.getSelectionModel().selectionModeProperty());
 
-        // visible extra buttons
-        CheckBox visibleExtraButtonsCheckBox = new CheckBox("Show Extra Buttons");
-        visibleExtraButtonsCheckBox.selectedProperty().bindBidirectional(selectionBox.showExtraButtonsProperty());
+        // show extra nodes
+        CheckBox showExtraNodesCheckBox = new CheckBox("Show Extra Nodes");
+        // cache the top node
+        Node selectionBoxTop = selectionBox.getTop();
+        showExtraNodesCheckBox.selectedProperty().subscribe(showExtraNodes -> {
+            if (showExtraNodes) {
+                selectionBox.setTop(topNode);
+                selectionBox.setBottom(bottomNode);
+                selectionBox.setLeft(leftNode);
+                selectionBox.setRight(rightNode);
+            } else {
+                selectionBox.setTop(selectionBoxTop);
+                selectionBox.setBottom(null);
+                selectionBox.setLeft(null);
+                selectionBox.setRight(null);
+            }
+        });
 
         // prompt text
         CheckBox promptTextCheckBox = new CheckBox("Change Prompt Text");
@@ -74,27 +105,6 @@ public class SelectionBoxApp extends Application {
                 selectionBox.setPromptText("No Selection");
             }
         });
-
-        // change extra buttons
-        Button changeExtraButtonsButton = new Button("Change Extra Buttons");
-        changeExtraButtonsButton.setMaxWidth(Double.MAX_VALUE);
-        changeExtraButtonsButton.setOnAction(e ->
-                selectionBox.setExtraButtonsProvider(model -> switch (model.getSelectionMode()) {
-                    case SINGLE -> List.of(
-                            selectionBox.createExtraButton("Select Previous", model::selectPrevious),
-                            selectionBox.createExtraButton("Select Next", model::selectNext)
-                    );
-                    case MULTIPLE -> List.of(
-                            selectionBox.createExtraButton("Select First", model::selectFirst),
-                            selectionBox.createExtraButton("Select Last", model::selectLast)
-                    );
-                })
-        );
-
-        // extra buttons position
-        ComboBox<SelectionBox.VerticalPosition> extraButtonsPositionComboBox = new ComboBox<>();
-        extraButtonsPositionComboBox.getItems().addAll(SelectionBox.VerticalPosition.values());
-        extraButtonsPositionComboBox.valueProperty().bindBidirectional(selectionBox.extraButtonsPositionProperty());
 
         // use custom string converter
         CheckBox useCustomStringConverterCheckBox = new CheckBox("Use Custom String Converter");
@@ -224,10 +234,8 @@ public class SelectionBoxApp extends Application {
                 "SelectionBox",
                 new SimpleControlPane.ControlItem("Show Popup", showButton),
                 new SimpleControlPane.ControlItem("Selection Mode", selectionModeComboBox),
+                new SimpleControlPane.ControlItem("Show Extra Nodes", showExtraNodesCheckBox),
                 new SimpleControlPane.ControlItem("Change Prompt Text", promptTextCheckBox),
-                new SimpleControlPane.ControlItem("Show Extra Buttons", visibleExtraButtonsCheckBox),
-                new SimpleControlPane.ControlItem("Change Extra Buttons", changeExtraButtonsButton),
-                new SimpleControlPane.ControlItem("Extra Buttons Position", extraButtonsPositionComboBox),
                 new SimpleControlPane.ControlItem("Use Custom String Converter", useCustomStringConverterCheckBox),
                 new SimpleControlPane.ControlItem("Auto Hide On Select", autoHideOnSelectCheckBox),
                 new SimpleControlPane.ControlItem("Select Method", selectTestButtonsBox),

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/SelectionBox.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/SelectionBox.java
@@ -52,7 +52,6 @@ public class SelectionBox<T> extends Control {
 
     private static final String DEFAULT_STYLE_CLASS = "selection-box";
     private static final boolean DEFAULT_READ_ONLY = false;
-    private static final boolean DEFAULT_SHOW_EXTRA_BUTTON = true;
 
     public SelectionBox() {
         getStyleClass().setAll("combo-box-base", "combo-box", DEFAULT_STYLE_CLASS);

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/TimeRangePicker.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/TimeRangePicker.java
@@ -1,7 +1,10 @@
 package com.dlsc.gemsfx;
 
 import com.dlsc.gemsfx.util.SimpleStringConverter;
+import javafx.scene.Node;
 import javafx.scene.control.Button;
+import javafx.scene.control.SelectionMode;
+import javafx.scene.layout.VBox;
 import javafx.util.StringConverter;
 
 import java.time.LocalTime;
@@ -38,18 +41,8 @@ public class TimeRangePicker extends SelectionBox<TimeRangePicker.TimeRange> {
         // Set time ranges
         getItems().setAll(ranges);
 
-        // set extra buttons
-        setExtraButtonsProvider(model -> switch (model.getSelectionMode()) {
-            case SINGLE -> {
-                Button clearButton = createExtraButton("Clear", getSelectionModel()::clearSelection);
-                yield List.of(clearButton);
-            }
-            case MULTIPLE -> {
-                Button clearButton = createExtraButton("Clear", model::clearSelection);
-                Button selectAllButton = createExtraButton("Select All", model::selectAll);
-                yield List.of(clearButton, selectAllButton);
-            }
-        });
+        // Add quick selection buttons to the top of the popup
+        setTop(createExtraButtonsBox());
 
         // set result converter
         setSelectedItemsConverter(new SimpleStringConverter<>(selectedRanges -> {
@@ -71,6 +64,23 @@ public class TimeRangePicker extends SelectionBox<TimeRangePicker.TimeRange> {
                 return String.join(", ", rangeStrings);
             }
         }));
+    }
+
+    private Node createExtraButtonsBox() {
+        Button clearButton = createExtraButton("Clear", getSelectionModel()::clearSelection);
+        clearButton.getStyleClass().add("clear-button");
+        clearButton.managedProperty().bind(clearButton.visibleProperty());
+        clearButton.visibleProperty().bind(itemsProperty().isNotNull().and(itemsProperty().emptyProperty().not()));
+
+        Button selectAllButton = createExtraButton("Select All", getSelectionModel()::selectAll);
+        selectAllButton.getStyleClass().add("select-all-button");
+        selectAllButton.managedProperty().bind(selectAllButton.visibleProperty());
+        selectAllButton.visibleProperty().bind(currentSelectionModeProperty().isEqualTo(SelectionMode.MULTIPLE));
+
+        VBox extraButtonsBox = new VBox(clearButton, selectAllButton);
+        extraButtonsBox.getStyleClass().addAll("extra-buttons-box");
+
+        return extraButtonsBox;
     }
 
     private List<TimeRange> mergeConsecutiveItem(List<TimeRange> ranges) {

--- a/gemsfx/src/main/resources/com/dlsc/gemsfx/selection-box.css
+++ b/gemsfx/src/main/resources/com/dlsc/gemsfx/selection-box.css
@@ -11,14 +11,21 @@
 .selection-popup > .content {
     -fx-background-color: -fx-box-border, -fx-control-inner-background;
     -fx-background-insets: 0, 1;
-    -fx-effect: dropshadow( three-pass-box , rgba(0,0,0,0.6) , 8, 0.0 , 0 , 0 );
+    -fx-effect: dropshadow(three-pass-box, rgba(0, 0, 0, 0.6), 8, 0.0, 0, 0);
     -fx-padding: 4px 1px;
+    -fx-max-height: 25em;
 }
 
 .selection-popup:above > .content {
 }
 
-.selection-popup > .content > .extra-buttons-box .extra-button {
+.selection-popup > .content .extra-buttons-box {
+    -fx-border-width: 0 0 1px 0;
+    -fx-border-color: transparent transparent derive(-fx-background, -20%) transparent;
+    -fx-padding: 0 0 1px 0;
+}
+
+.selection-popup > .content .extra-buttons-box .extra-button {
     -fx-background-radius: 2px;
     -fx-alignment: center-left;
     -fx-text-fill: -fx-text-base-color;
@@ -26,43 +33,60 @@
     -fx-background-color: -fx-control-inner-background;
 }
 
-.selection-popup > .content > .extra-buttons-box .extra-button:hover {
+.selection-popup > .content .extra-buttons-box .extra-button:hover {
     -fx-background-color: -fx-cell-hover-color;
     -fx-text-fill: -fx-text-inner-color;
 }
 
-.selection-popup > .content > .extra-buttons-box .extra-button:pressed {
+.selection-popup > .content .extra-buttons-box .extra-button:pressed {
     -fx-background-color: derive(-fx-cell-hover-color, 5%);
 }
 
-.selection-popup > .content > .options-box > .radio-button,
-.selection-popup > .content > .options-box > .check-box {
+.selection-popup > .content > .options-scroll-pane {
+    -fx-background-color: -fx-control-inner-background;
+    -fx-background-insets: 0;
+    -fx-padding: 0;
+}
+
+.selection-popup > .content > .options-scroll-pane:focused {
+    -fx-background-insets: 0;
+}
+
+.selection-popup > .content > .options-scroll-pane .viewport {
+    -fx-background-color: -fx-control-inner-background;
+}
+
+.selection-popup > .content > .options-scroll-pane .options-box {
+}
+
+.selection-popup > .content > .options-scroll-pane .options-box > .radio-button,
+.selection-popup > .content > .options-scroll-pane .options-box > .check-box {
     -fx-label-padding: 0 0 0 4px;
     -fx-text-fill: -fx-text-base-color;
     -fx-padding: 4 0 4 5;
     -fx-background-color: -fx-control-inner-background;
 }
 
-.selection-popup > .content > .options-box > .radio-button:hover,
-.selection-popup > .content > .options-box > .check-box:hover {
+.selection-popup > .content > .options-scroll-pane .options-box > .radio-button:hover,
+.selection-popup > .content > .options-scroll-pane .options-box > .check-box:hover {
     -fx-background-color: -fx-cell-hover-color;
     -fx-text-fill: -fx-text-inner-color;
 }
 
-.selection-popup > .content > .options-box > .radio-button > .radio {
+.selection-popup > .content > .options-scroll-pane .options-box > .radio-button > .radio {
     -fx-background-color: transparent;
 }
 
-.selection-popup > .content > .options-box > .radio-button > .radio > .dot {
+.selection-popup > .content > .options-scroll-pane .options-box > .radio-button > .radio > .dot {
     -fx-shape: "M7.95837 15L3.20837 10.25L4.39587 9.06249L7.95837 12.625L15.6042 4.97916L16.7917 6.16666L7.95837 15Z";
 }
 
-.selection-popup > .content > .options-box > .radio-button:selected {
+.selection-popup > .content > .options-scroll-pane .options-box > .radio-button:selected {
     -fx-background: -fx-accent;
     -fx-background-color: -fx-selection-bar;
     -fx-text-fill: -fx-selection-bar-text;
 }
 
-.selection-popup > .content > .options-box > .radio-button:selected > .radio > .dot {
+.selection-popup > .content > .options-scroll-pane .options-box > .radio-button:selected > .radio > .dot {
     -fx-background-color: -fx-selection-bar-text;
 }


### PR DESCRIPTION

- Use a ScrollPane to prevent the popup from growing too large with many options
- Replace extraButtons with a more flexible approach: extra nodes on top, bottom, left, and right