### PR TITLE
Ensure SVGImageView updates when window render scale changes

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SVGImageViewSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SVGImageViewSkin.java
@@ -4,6 +4,8 @@ import com.dlsc.gemsfx.SVGImageView;
 import com.dlsc.gemsfx.util.SVGUtil;
 import javafx.beans.InvalidationListener;
 import javafx.beans.WeakInvalidationListener;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.value.ChangeListener;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
 import javafx.scene.Scene;
@@ -11,10 +13,16 @@ import javafx.scene.control.SkinBase;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.Region;
+import javafx.stage.Window;
+import one.jpro.platform.utils.TreeShowing;
 
 import java.net.URI;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class SVGImageViewSkin extends SkinBase<SVGImageView> {
+
+    private final Logger LOG = Logger.getLogger(SVGImageViewSkin.class.getName());
 
     private Service<Image> imageService;
     private final ImageView imageView = new ImageView();
@@ -38,35 +46,91 @@ public class SVGImageViewSkin extends SkinBase<SVGImageView> {
         loadingImage();
         getChildren().add(imageView);
 
-        registerWindowScaleListeners(svgImageView);
+        initializeTreeShowingScaleListeners();
     }
 
-    /**
-     * Registers listeners on the current Scene and its Window for render-scale changes.
-     * <p>
-     * This ensures that when the {@link Scene} or its {@link javafx.stage.Window} changes (e.g., moving
-     * from a normal DPI display to a high DPI/4K display), the renderScaleX and renderScaleY
-     * property listeners will be added or removed appropriately.
-     *
-     * @param svgImageView the SVGImageView whose Scene and Window changes need to be tracked.
-     */
-    private void registerWindowScaleListeners(SVGImageView svgImageView) {
-        Scene scene = svgImageView.getScene();
-        if (scene != null && scene.getWindow() != null) {
-            scene.getWindow().renderScaleXProperty().addListener(weakListener);
-            scene.getWindow().renderScaleYProperty().addListener(weakListener);
+    private void initializeTreeShowingScaleListeners() {
+        BooleanProperty treeShowing = TreeShowing.treeShowing(getSkinnable());
+        if (treeShowing.get()) {
+            attachWindowScaleListeners();
         }
 
-        svgImageView.sceneProperty().addListener((obs, oldScene, newScene) -> {
-            if (oldScene != null && oldScene.getWindow() != null) {
-                oldScene.getWindow().renderScaleXProperty().removeListener(weakListener);
-                oldScene.getWindow().renderScaleYProperty().removeListener(weakListener);
-            }
-            if (newScene != null && newScene.getWindow() != null) {
-                newScene.getWindow().renderScaleXProperty().addListener(weakListener);
-                newScene.getWindow().renderScaleYProperty().addListener(weakListener);
+        treeShowing.addListener((obs, wasShowing, isNowShowing) -> {
+            if (isNowShowing) {
+                attachWindowScaleListeners();
+            } else {
+                detachWindowScaleListeners();
             }
         });
+    }
+
+    private void attachWindowScaleListeners() {
+        SVGImageView svgImageView = getSkinnable();
+        Scene currentScene = svgImageView.getScene();
+        if (currentScene == null) {
+            return;
+        }
+
+        currentScene.windowProperty().addListener(windowChangeListener);
+
+        Window window = currentScene.getWindow();
+        if (window != null) {
+            attachScaleListeners(window);
+        }
+
+        svgImageView.sceneProperty().addListener(sceneChangeListener);
+    }
+
+    private void detachWindowScaleListeners() {
+        SVGImageView svgImageView = getSkinnable();
+        Scene currentScene = svgImageView.getScene();
+        if (currentScene != null) {
+            currentScene.windowProperty().removeListener(windowChangeListener);
+
+            Window window = currentScene.getWindow();
+            if (window != null) {
+                detachScaleListeners(window);
+            }
+        }
+        svgImageView.sceneProperty().removeListener(sceneChangeListener);
+    }
+
+    private final ChangeListener<Window> windowChangeListener = (observable, oldWindow, newWindow) -> {
+        if (oldWindow != null) {
+            detachScaleListeners(oldWindow);
+        }
+        if (newWindow != null) {
+            attachScaleListeners(newWindow);
+        }
+    };
+
+    private final ChangeListener<Scene> sceneChangeListener = (observable, oldScene, newScene) -> {
+        if (oldScene != null) {
+            oldScene.windowProperty().removeListener(windowChangeListener);
+            Window oldWindow = oldScene.getWindow();
+            if (oldWindow != null) {
+                detachScaleListeners(oldWindow);
+            }
+        }
+        if (newScene != null) {
+            newScene.windowProperty().addListener(windowChangeListener);
+            Window newWindow = newScene.getWindow();
+            if (newWindow != null) {
+                attachScaleListeners(newWindow);
+            }
+        }
+    };
+
+    private void attachScaleListeners(Window window) {
+        // ensure no duplicate
+        detachScaleListeners(window);
+        window.renderScaleXProperty().addListener(weakListener);
+        window.renderScaleYProperty().addListener(weakListener);
+    }
+
+    private void detachScaleListeners(Window window) {
+        window.renderScaleXProperty().removeListener(weakListener);
+        window.renderScaleYProperty().removeListener(weakListener);
     }
 
     private void loadingImage() {
@@ -94,17 +158,18 @@ public class SVGImageViewSkin extends SkinBase<SVGImageView> {
                 imageView.setImage(image);
             } catch (Exception e) {
                 imageView.setImage(null);
+                LOG.log(Level.WARNING, "Failed to load image: " + e.getMessage(), e);
             }
         } else {
             if (imageService == null) {
-                imageService = createLoadingImageService();
+                imageService = createLoadingImageService(sX, sY);
                 imageService.setOnSucceeded(evt -> imageView.setImage(imageService.getValue()));
             }
             imageService.restart();
         }
     }
 
-    private Service<Image> createLoadingImageService() {
+    private Service<Image> createLoadingImageService(double sX, double sY) {
         SVGImageView skinnable = getSkinnable();
         return new Service<>() {
             @Override
@@ -116,8 +181,9 @@ public class SVGImageViewSkin extends SkinBase<SVGImageView> {
                             return null;
                         }
                         try {
-                            return SVGUtil.parseSVGFromUrl(new URI(skinnable.getSvgUrl()).toURL(), skinnable.getFitWidth(), skinnable.getFitHeight());
+                            return SVGUtil.parseSVGFromUrl(new URI(skinnable.getSvgUrl()).toURL(), skinnable.getFitWidth() * sX, skinnable.getFitHeight() * sY);
                         } catch (Exception e) {
+                            LOG.log(Level.WARNING, "Failed to load image: " + e.getMessage(), e);
                             return null;
                         }
                     }

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SVGImageViewSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SVGImageViewSkin.java
@@ -101,6 +101,9 @@ public class SVGImageViewSkin extends SkinBase<SVGImageView> {
         }
         if (newWindow != null) {
             attachScaleListeners(newWindow);
+
+            // Force immediate image reload to reflect the new Window's render scale.
+            loadingImage();
         }
     };
 


### PR DESCRIPTION
@yetyman Thanks for reporting this issue and for your proposed solutions! We've implemented a fix based on your feedback by properly tracking renderScaleX and renderScaleY changes when switching screens.

Implemented listeners to track changes in Scene and Window properties for dynamic render scale adjustments. Updated SVG loading to respect render scale factors, ensuring proper scaling on high-DPI displays. This improves display consistency across different screen resolutions.
#218 