### PR TITLE
Fix SimpleStringConverter to properly apply nullDefaultValue

### DIFF
--- a/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/util/SimpleStringConverterDemo.java
+++ b/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/util/SimpleStringConverterDemo.java
@@ -1,5 +1,6 @@
 package com.dlsc.gemsfx.demo.util;
 
+import com.dlsc.gemsfx.util.EnumUtil;
 import com.dlsc.gemsfx.util.SimpleStringConverter;
 import javafx.application.Application;
 import javafx.geometry.Insets;
@@ -24,6 +25,17 @@ public class SimpleStringConverterDemo extends Application {
     public record Task(String description, LocalDate dueDate) {
     }
 
+    private enum Status {
+        OPEN,
+        IN_PROGRESS,
+        DONE;
+
+        @Override
+        public String toString() {
+            return EnumUtil.formatEnumNameAsTitleCase(this);
+        }
+    }
+
     @Override
     public void start(Stage primaryStage) {
         // Create a ComboBox and populate it with Task objects
@@ -31,6 +43,7 @@ public class SimpleStringConverterDemo extends Application {
         comboBox.getItems().addAll(
                 new Task("Task 1", LocalDate.now().plusWeeks(3)),
                 new Task("Task 2", LocalDate.now().plusWeeks(5)),
+                null,
                 new Task("Task 3", LocalDate.now().plusWeeks(6))
         );
         comboBox.getSelectionModel().selectFirst();
@@ -42,7 +55,7 @@ public class SimpleStringConverterDemo extends Application {
         //         if (object != null) {
         //             return object.description() + "  [Due: " + object.dueDate() +"]";
         //         }
-        //         return "";
+        //         return "No Task";
         //     }
         //
         //     @Override
@@ -52,12 +65,35 @@ public class SimpleStringConverterDemo extends Application {
         // });
 
         // Set the converter to use SimpleStringConverter with the default title case formatting
-        comboBox.setConverter(new SimpleStringConverter<>(task -> task.description() + "  [Due: " + task.dueDate() + "]", ""));
+        comboBox.setConverter(new SimpleStringConverter<>(task -> task.description() + "  [Due: " + task.dueDate() + "]", "No Task"));
+
+        ComboBox<Status> statusComboBox = new ComboBox<>();
+        statusComboBox.getItems().addAll(Status.OPEN, null, Status.IN_PROGRESS, Status.DONE);
+        statusComboBox.getSelectionModel().selectFirst();
+
+        // For enum types, you can use EnumStringConverter directly instead of SimpleStringConverter.
+        // This approach eliminates the need to override the toString() method in the Status enum,
+        // as long as the default conversion logic meets your requirements.
+        //
+        // By default, EnumStringConverter (with the no-argument constructor):
+        //  - Converts null values to an empty string ("").
+        //  - Formats enum names in title case (e.g., "IN_PROGRESS" → "In Progress").
+        //
+        // Example usage:
+        //
+        // statusComboBox.setConverter(new EnumStringConverter<>());
+        //  With this, you no longer need to override toString() in the Status enum.
+        //
+        statusComboBox.setConverter(new SimpleStringConverter<>());
 
         // Create a VBox layout and add the ComboBox to it
-        Label label = new Label("Select a status:");
+        Label label = new Label("Select a task:");
         label.setFont(new Font(16));
-        VBox vbox = new VBox(15, label, comboBox);
+
+        Label statusLabel = new Label("Select a status:");
+        statusLabel.setFont(new Font(16));
+
+        VBox vbox = new VBox(15, label, comboBox, statusLabel, statusComboBox);
         vbox.setPadding(new Insets(15));
         vbox.setAlignment(Pos.CENTER);
         Scene scene = new Scene(vbox, 300, 200);

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/util/SimpleStringConverter.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/util/SimpleStringConverter.java
@@ -46,8 +46,13 @@ public class SimpleStringConverter<T> extends StringConverter<T> {
 
     private final Callback<T, String> valueToStringCallback;
 
+    /**
+     * Creates a new {@code SimpleStringConverter} with a default callback:
+     * if the object is non-null, its {@code toString()} method is used;
+     * if the object is null, an empty string ("") is returned.
+     */
     public SimpleStringConverter() {
-        this(Object::toString, "");
+        this.valueToStringCallback = value -> value == null ? "" : value.toString();
     }
 
     /**
@@ -76,7 +81,7 @@ public class SimpleStringConverter<T> extends StringConverter<T> {
 
     @Override
     public String toString(T object) {
-        if (this.valueToStringCallback != null && object != null) {
+        if (this.valueToStringCallback != null) {
             return this.valueToStringCallback.call(object);
         }
         return "";


### PR DESCRIPTION
## Issue
Previously, `SimpleStringConverter` had an issue where `nullDefaultValue` was not applied correctly.
This happened because the `toString(T object)` method explicitly returned `""` when the object was `null`,
bypassing the intended handling in the constructor.

## Fix
- Now, `toString(T object)` always calls `valueToStringCallback.call(object)`, ensuring the logic set 
  in the constructor (including `nullDefaultValue`) is properly applied.
- Updated the default constructor to safely handle null values without causing NullPointerException.
- Improved documentation for better clarity.

## Impact
- Any existing usage where null handling depended on `nullDefaultValue` should now work as expected.
- No breaking changes, but behavior for null values will now respect the provided `nullDefaultValue`.
