### PR TITLE
Ensure proper width calculation in SelectionBoxSkin popup.

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SelectionBoxSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SelectionBoxSkin.java
@@ -366,7 +366,10 @@ public class SelectionBoxSkin<T> extends SkinBase<SelectionBox<T>> {
 
             Node popupNode = getSkin().getNode();
             if (popupNode instanceof Region region) {
-                region.setPrefWidth(bounds.getWidth());
+                region.setPrefWidth(Region.USE_COMPUTED_SIZE);
+                double popupNodeWidth = region.prefWidth(-1);
+                double prefWidth = Math.max(bounds.getWidth(), popupNodeWidth);
+                region.setPrefWidth(prefWidth);
             }
 
             if (owner.isAnimationEnabled()) {
@@ -455,6 +458,7 @@ public class SelectionBoxSkin<T> extends SkinBase<SelectionBox<T>> {
             optionsBox = new VBox();
             optionsBox.getStyleClass().add("options-box");
             optionsBox.setFillWidth(true);
+            optionsBox.setMinWidth(Region.USE_PREF_SIZE);
             optionsBox.managedProperty().bind(optionsBox.visibleProperty());
             optionsBox.visibleProperty().bind(popup.getOwner().itemsProperty().emptyProperty().not());
 
@@ -466,6 +470,13 @@ public class SelectionBoxSkin<T> extends SkinBase<SelectionBox<T>> {
             ScrollPane scrollPane = new ScrollPane(optionsBox);
             scrollPane.getStyleClass().add("options-scroll-pane");
             scrollPane.setFitToWidth(true);
+
+            optionsBox.widthProperty().addListener((obs, oldWidth, newWidth) -> {
+                if (scrollPane.getPrefViewportWidth() == 0.0) {
+                    scrollPane.setPrefViewportWidth(newWidth.doubleValue());
+                }
+            });
+
             contentPane.setCenter(scrollPane);
 
             // Initialize the popup content

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SelectionBoxSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SelectionBoxSkin.java
@@ -438,6 +438,7 @@ public class SelectionBoxSkin<T> extends SkinBase<SelectionBox<T>> {
         private final SelectionPopup popup;
         private final BorderPane contentPane;
         private final VBox optionsBox;
+        private final ScrollPane scrollPane;
 
         // Use indices as keys to handle duplicate items
         private final Map<Integer, BooleanProperty> itemButtonProperties = new LinkedHashMap<>();
@@ -467,7 +468,7 @@ public class SelectionBoxSkin<T> extends SkinBase<SelectionBox<T>> {
             contentPane.leftProperty().bind(control.leftProperty());
             contentPane.rightProperty().bind(control.rightProperty());
 
-            ScrollPane scrollPane = new ScrollPane(optionsBox);
+            scrollPane = new ScrollPane(optionsBox);
             scrollPane.getStyleClass().add("options-scroll-pane");
             scrollPane.setFitToWidth(true);
 
@@ -499,6 +500,7 @@ public class SelectionBoxSkin<T> extends SkinBase<SelectionBox<T>> {
         }
 
         private void updatePopupContent() {
+            scrollPane.setPrefViewportWidth(0.0);
             optionsBox.getChildren().clear();
             itemButtonProperties.clear();
 

--- a/gemsfx/src/main/resources/com/dlsc/gemsfx/selection-box.css
+++ b/gemsfx/src/main/resources/com/dlsc/gemsfx/selection-box.css
@@ -17,9 +17,6 @@
     -fx-translate-y: 2px;
 }
 
-.selection-popup:above > .content {
-}
-
 .selection-popup > .content .extra-buttons-box {
     -fx-border-width: 0 0 1px 0;
     -fx-border-color: transparent transparent derive(-fx-background, -20%) transparent;
@@ -30,7 +27,7 @@
     -fx-background-radius: 2px;
     -fx-alignment: center-left;
     -fx-text-fill: -fx-text-base-color;
-    -fx-padding: 4 0 4 26;
+    -fx-padding: 4 4 4 26;
     -fx-background-color: -fx-control-inner-background;
 }
 
@@ -64,7 +61,7 @@
 .selection-popup > .content > .options-scroll-pane .options-box > .check-box {
     -fx-label-padding: 0 0 0 4px;
     -fx-text-fill: -fx-text-base-color;
-    -fx-padding: 4 0 4 5;
+    -fx-padding: 4px;
     -fx-background-color: -fx-control-inner-background;
 }
 


### PR DESCRIPTION
Revised the `SelectionBoxSkin` popup to compute its preferred width dynamically based on content and bounds, improving layout flexibility. Added a listener to adjust the viewport width of the scroll pane dynamically based on the options box width. These changes enhance visual consistency and adaptability.