### PR TITLE
Fix: allow closing popup by clicking already-selected item in SINGLE mode

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SelectionBoxSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SelectionBoxSkin.java
@@ -25,6 +25,7 @@ import javafx.scene.control.SelectionMode;
 import javafx.scene.control.Skin;
 import javafx.scene.control.SkinBase;
 import javafx.scene.control.ToggleGroup;
+import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Region;
@@ -538,13 +539,17 @@ public class SelectionBoxSkin<T> extends SkinBase<SelectionBox<T>> {
             radioButton.setMaxWidth(Double.MAX_VALUE);
             radioButton.setToggleGroup(toggleGroup);
             radioButton.setSelected(popup.getOwner().getSelectionModel().isSelected(index));
-            radioButton.setOnAction(e -> {
-                if (!isUpdating()) {
-                    if (radioButton.isSelected()) {
+            // Use onMouseClicked instead of onAction to ensure click on already-selected item still closes popup
+            radioButton.setOnMouseClicked(e -> {
+                if (!isUpdating() && e.getButton() == MouseButton.PRIMARY) {
+                    boolean alreadySelected = popup.getOwner().getSelectionModel().isSelected(index);
+
+                    if (!alreadySelected) {
                         popup.getOwner().getSelectionModel().clearAndSelect(index);
-                        if (popup.getOwner().isAutoHideOnSelection()) {
-                            popup.hide();
-                        }
+                    }
+
+                    if (popup.getOwner().isAutoHideOnSelection()) {
+                        popup.hide();
                     }
                 }
             });


### PR DESCRIPTION
This PR addresses an issue in SelectionBox when using SelectionMode.SINGLE.
In the original behavior, clicking on an already-selected RadioButton does not trigger any action due to JavaFX's default event handling — preventing the popup from closing.

Replaced setOnAction with setOnMouseClicked in createRadioButtonItem(...)

Ensures that:

Clicking a new item will update selection

Clicking an already-selected item will still close the popup if autoHideOnSelection is true

This results in a more intuitive and consistent selection behavior for end users.