### PR TITLE
Optimize selectAll to avoid multiple listener triggers and improve batch performance

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/util/CustomMultipleSelectionModel.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/util/CustomMultipleSelectionModel.java
@@ -267,15 +267,20 @@ public class CustomMultipleSelectionModel<T> extends MultipleSelectionModel<T> {
 
         if (getSelectionMode() == SelectionMode.SINGLE) {
             select(0);
-        } else {
-            clearSelection();
-            for (int i = 0; i < items.size(); i++) {
-                selectedIndices.add(i);
-                selectedItems.add(items.get(i));
-            }
-            setSelectedIndex(items.size() - 1);
-            setSelectedItem(items.get(items.size() - 1));
+            return;
         }
+
+        int size = items.size();
+        List<Integer> indexList = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            indexList.add(i);
+        }
+
+        selectedIndices.setAll(indexList);
+        selectedItems.setAll(new ArrayList<>(items));
+
+        setSelectedIndex(size - 1);
+        setSelectedItem(items.get(size - 1));
     }
 
     @Override


### PR DESCRIPTION
### Problem

The previous `CustomMultipleSelectionModel.selectAll()` implementation added selected indices and items one by one, which could result in:

- Multiple `ListChangeListener` and `InvalidationListener` triggers
- Performance issues when handling large datasets

### Solution

This PR rewrites `selectAll()` to:

- Build a pre-sized index list in a single pass
- Batch-update both `selectedIndices` and `selectedItems`
- Ensure only one change event is fired per list update