### PR TITLE
Fix: SelectionBox fails to update popup content when items change before skin is initialized

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SelectionBoxSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SelectionBoxSkin.java
@@ -494,11 +494,9 @@ public class SelectionBoxSkin<T> extends SkinBase<SelectionBox<T>> {
                 if (change.wasAdded()) {
                     if (UPDATE_POPUP_CONTENT.equals(change.getKey())) {
                         updatePopupContent();
-                        popup.getProperties().remove(UPDATE_POPUP_CONTENT);
                     }
                     if (UPDATE_SELECTION_IN_POPUP.equals(change.getKey())) {
                         updateSelectionInPopup();
-                        popup.getProperties().remove(UPDATE_SELECTION_IN_POPUP);
                     }
                 }
             });
@@ -530,6 +528,8 @@ public class SelectionBoxSkin<T> extends SkinBase<SelectionBox<T>> {
                     optionsBox.getChildren().add(radioButton);
                 }
             }
+            // Always clear the update flag to avoid blocking future updates.
+            popup.getProperties().remove(UPDATE_POPUP_CONTENT);
         }
 
         private RadioButton createRadioButtonItem(T item, ToggleGroup toggleGroup, int index) {
@@ -587,6 +587,8 @@ public class SelectionBoxSkin<T> extends SkinBase<SelectionBox<T>> {
             }
 
             updating.set(false);
+            // Always clear the update flag to avoid blocking future updates.
+            popup.getProperties().remove(UPDATE_SELECTION_IN_POPUP);
         }
 
         // updating


### PR DESCRIPTION
### Problem

Under normal conditions, the popup content of `SelectionBox` updates correctly when `itemsProperty` changes.

However, in a rare but valid edge case, the update may silently fail:

> If the `itemsProperty` is bound and changes **before the popup skin is initialized**, the `"updatePopupContent"` flag is set too early and never consumed—because the listener hasn't been registered yet. This prevents future updates from triggering.

### Solution

Move the `popup.getProperties().remove(...)` calls into the `updatePopupContent()` and `updateSelectionInPopup()` methods themselves. This ensures the trigger flags are always cleared after consumption, even during delayed skin initialization.