### PR TITLE
Refactor: Correct getBean to return outer instance

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/ArcProgressIndicator.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/ArcProgressIndicator.java
@@ -16,7 +16,6 @@ import javafx.util.StringConverter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * ArcProgressIndicator is a visual control used to indicate the progress of a task.
@@ -149,7 +148,7 @@ public abstract class ArcProgressIndicator extends ProgressIndicator {
             progressArcType = new StyleableObjectProperty<>(DEFAULT_PROGRESS_ARC_TYPE) {
                 @Override
                 public Object getBean() {
-                    return this;
+                    return ArcProgressIndicator.this;
                 }
 
                 @Override
@@ -186,7 +185,7 @@ public abstract class ArcProgressIndicator extends ProgressIndicator {
             trackArcType = new StyleableObjectProperty<>(DEFAULT_TRACK_ARC_TYPE) {
                 @Override
                 public Object getBean() {
-                    return this;
+                    return ArcProgressIndicator.this;
                 }
 
                 @Override
@@ -231,7 +230,7 @@ public abstract class ArcProgressIndicator extends ProgressIndicator {
             styleType = new StyleableObjectProperty<>(DEFAULT_STYLE_TYPE) {
                 @Override
                 public Object getBean() {
-                    return this;
+                    return ArcProgressIndicator.this;
                 }
 
                 @Override

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/DialogPane.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/DialogPane.java
@@ -35,12 +35,18 @@ import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
 import javafx.event.WeakEventHandler;
 import javafx.geometry.Insets;
-import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.control.*;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListView;
+import javafx.scene.control.ProgressIndicator;
+import javafx.scene.control.TextField;
+import javafx.scene.control.TextInputControl;
 import javafx.scene.control.skin.ButtonBarSkin;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
@@ -66,7 +72,13 @@ import org.kordamp.ikonli.materialdesign.MaterialDesign;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -2199,7 +2211,7 @@ public class DialogPane extends Pane {
 
                 @Override
                 public Object getBean() {
-                    return this;
+                    return CircularProgressIndicator.this;
                 }
 
                 @Override
@@ -2210,7 +2222,7 @@ public class DialogPane extends Pane {
             indeterminate = new BooleanPropertyBase(false) {
                 @Override
                 public Object getBean() {
-                    return this;
+                    return CircularProgressIndicator.this;
                 }
 
                 @Override
@@ -2232,7 +2244,7 @@ public class DialogPane extends Pane {
 
                 @Override
                 public Object getBean() {
-                    return this;
+                    return CircularProgressIndicator.this;
                 }
 
                 @Override

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/ResponsivePane.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/ResponsivePane.java
@@ -1,8 +1,17 @@
 package com.dlsc.gemsfx;
 
-import javafx.beans.property.*;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ObjectPropertyBase;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.ListChangeListener;
-import javafx.css.*;
+import javafx.css.CssMetaData;
+import javafx.css.PseudoClass;
+import javafx.css.Styleable;
+import javafx.css.StyleableDoubleProperty;
+import javafx.css.StyleableObjectProperty;
+import javafx.css.StyleableProperty;
 import javafx.css.converter.EnumConverter;
 import javafx.css.converter.SizeConverter;
 import javafx.geometry.Insets;
@@ -24,7 +33,6 @@ import java.util.Objects;
  * When the window width is wide, both the large sidebar and the main content pane are shown.
  * Similarly, if the sidebar is positioned at the TOP or BOTTOM, its visibility will be adjusted based on the height of the pane.
  * However, it is also possible to force the sidebar to be displayed regardless of the window size.
- *
  */
 public class ResponsivePane extends Pane {
 
@@ -193,7 +201,7 @@ public class ResponsivePane extends Pane {
 
                 @Override
                 public Object getBean() {
-                    return this;
+                    return ResponsivePane.this;
                 }
 
                 @Override
@@ -240,7 +248,7 @@ public class ResponsivePane extends Pane {
 
                 @Override
                 public Object getBean() {
-                    return this;
+                    return ResponsivePane.this;
                 }
 
                 @Override
@@ -568,7 +576,7 @@ public class ResponsivePane extends Pane {
 
         @Override
         public Object getBean() {
-            return this;
+            return ResponsivePane.this;
         }
 
         @Override


### PR DESCRIPTION
This change updates `getBean` implementations across multiple classes to return the enclosing class instance instead of `this`. Additionally, redundant imports were cleaned up and explicit imports were added for better clarity and maintainability.