### PR TITLE
enhancing search field functionality

### DIFF
--- a/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SearchFieldApp.java
+++ b/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/SearchFieldApp.java
@@ -4,7 +4,6 @@ import com.dlsc.gemsfx.SearchField;
 import com.dlsc.gemsfx.util.HistoryManager;
 import com.dlsc.gemsfx.util.StringHistoryManager;
 import fr.brouillard.oss.cssfx.CSSFX;
-import javafx.application.Application;
 import javafx.beans.binding.Bindings;
 import javafx.geometry.Insets;
 import javafx.scene.Scene;
@@ -78,13 +77,16 @@ public class SearchFieldApp extends GemApplication {
         usePlaceholder.setSelected(true);
         field.placeholderProperty().bind(Bindings.createObjectBinding(() -> usePlaceholder.isSelected() ? new Label("No countries found") : null, usePlaceholder.selectedProperty()));
 
+        CheckBox showSearchWhenEmptyChoiceBox = new CheckBox("Show search options on focus, before text has been typed");
+        showSearchWhenEmptyChoiceBox.selectedProperty().bindBidirectional(field.suggestWhenBlankProperty());
+
         CheckBox hideWithSingleChoiceBox = new CheckBox("Hide popup if it has only the currently selected item in it");
         hideWithSingleChoiceBox.selectedProperty().bindBidirectional(field.hidePopupWithSingleChoiceProperty());
 
         CheckBox hideWithNoChoiceBox = new CheckBox("Hide popup if it has no selectable items in it");
         hideWithNoChoiceBox.selectedProperty().bindBidirectional(field.hidePopupWithNoChoiceProperty());
 
-        CheckBox showSearchIconBox = new CheckBox("Show search icon");
+        CheckBox showSearchIconBox = new CheckBox("Show history icon");
         showSearchIconBox.selectedProperty().bindBidirectional(field.showSearchIconProperty());
 
         CheckBox showLeftRightNodes = new CheckBox("Show extra left & right nodes");
@@ -130,7 +132,7 @@ public class SearchFieldApp extends GemApplication {
         field.leftProperty().bind(Bindings.createObjectBinding(() -> showLeftRightNodes.isSelected() ? regionLeft : null, showLeftRightNodes.selectedProperty()));
         field.rightProperty().bind(Bindings.createObjectBinding(() -> showLeftRightNodes.isSelected() ? regionRight : null, showLeftRightNodes.selectedProperty()));
 
-        VBox vbox = new VBox(20, createNewItemBox, showPromptText, usePlaceholder, hideWithSingleChoiceBox, hideWithNoChoiceBox, showSearchIconBox, showLeftRightNodes,
+        VBox vbox = new VBox(20, createNewItemBox, showPromptText, usePlaceholder, showSearchWhenEmptyChoiceBox, hideWithSingleChoiceBox, hideWithNoChoiceBox, showSearchIconBox, showLeftRightNodes,
                 autoCommitOnFocusLostBox, hBox, hBox2, enableHistoryBox, historyControls, field);
         vbox.setPadding(new Insets(20));
 

--- a/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/TagsFieldApp.java
+++ b/gemsfx-demo/src/main/java/com/dlsc/gemsfx/demo/TagsFieldApp.java
@@ -2,7 +2,6 @@ package com.dlsc.gemsfx.demo;
 
 import com.dlsc.gemsfx.TagsField;
 import fr.brouillard.oss.cssfx.CSSFX;
-import javafx.application.Application;
 import javafx.beans.binding.Bindings;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/HistoryButton.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/HistoryButton.java
@@ -1,7 +1,6 @@
 package com.dlsc.gemsfx;
 
 import com.dlsc.gemsfx.util.HistoryManager;
-import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.*;
 import javafx.css.PseudoClass;
@@ -67,29 +66,32 @@ public class HistoryButton<T> extends Button {
     }
 
     /**
-     * Shows the popup that includes the list view with the items stored by the history manager.
+     * Toggles visibility of the popup that includes the list view with the items stored by the history manager.
      */
     public void showPopup() {
         Node owner = getOwner();
 
+        boolean hasHistory = getHistoryManager() != null;
+
+        if (hasHistory) {
+            if (popup == null) {
+                popup = new HistoryPopup();
+                popupShowing.bind(popup.showingProperty());
+            }
+
+            if (popup.isShowing()) {
+                hidePopup();
+            }
+            else {
+                popup.show(this);
+            }
+        }
+
+        //begin showing history BEFORE focusing owner, so that owner can sense that history is about to show
         if (owner != null && owner != this && !owner.isFocused()) {
             owner.requestFocus();
         }
 
-        if (getHistoryManager() == null) {
-            return;
-        }
-
-        if (popup == null) {
-            popup = new HistoryPopup();
-            popupShowing.bind(popup.showingProperty());
-        }
-
-        if (popup.isShowing()) {
-            hidePopup();
-        } else {
-            popup.show(this);
-        }
     }
 
     /**

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/TagsField.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/TagsField.java
@@ -130,12 +130,12 @@ public class TagsField<T> extends SearchField<T> {
      * @param newSuggestions the new suggestions to use for the field
      */
     @Override
-    protected void update(Collection<T> newSuggestions) {
+    protected void setSuggestions(Collection<T> newSuggestions) {
         if (newSuggestions != null) {
             newSuggestions.removeAll(getTags());
         }
 
-        super.update(newSuggestions);
+        super.setSuggestions(newSuggestions);
     }
 
     private final ListProperty<T> tags = new SimpleListProperty<>(this, "tags", FXCollections.observableArrayList());

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SearchFieldEditorSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SearchFieldEditorSkin.java
@@ -123,6 +123,7 @@ public class SearchFieldEditorSkin<T> extends TextFieldSkin {
 
     @Override
     protected void layoutChildren(double x, double y, double w, double h) {
+//        super.layoutChildren(x,y,w,h);
         double fullHeight = h + snappedTopInset() + snappedBottomInset();
 
         double leftWidth = leftPane == null ? 0.0 : snapSizeX(leftPane.prefWidth(fullHeight));

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SearchFieldPopupSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SearchFieldPopupSkin.java
@@ -108,11 +108,6 @@ public class SearchFieldPopupSkin<T> implements Skin<SearchFieldPopup<T>> {
         T selectedItem = listView.getSelectionModel().getSelectedItem();
         if (selectedItem != null) {
             searchField.select(selectedItem);
-            searchField.commit();
-            Consumer<T> onCommit = searchField.getOnCommit();
-            if (onCommit != null) {
-                onCommit.accept(selectedItem);
-            }
         }
     }
 


### PR DESCRIPTION
-not showing search while history popup is visible
-allowing search on blank prompt
-recording user text in lastUserText
-enhancing auto text preview to match popup
-adding common auto complete by tab click
-fixing search thread safety issues
-only setting "newItem" property once per operation rather than twice for clearer eventing
-removing search delay now that search is thread safe 
-fixing left right arrow actions in the search field editor 
-fix new item producer usages