### PR TITLE
refactor(SearchFieldPopupSkin): remove redundant width bindings for ListView

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SearchFieldPopupSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SearchFieldPopupSkin.java
@@ -39,13 +39,8 @@ public class SearchFieldPopupSkin<T> implements Skin<SearchFieldPopup<T>> {
 
         listView.getStyleClass().add("search-field-list-view");
         listView.cellFactoryProperty().bind(searchField.cellFactoryProperty());
-
-        listView.prefWidthProperty().bind(control.prefWidthProperty());
-        listView.maxWidthProperty().bind(control.maxWidthProperty());
         listView.minWidthProperty().bind(control.minWidthProperty());
-
         listView.placeholderProperty().bind(searchField.placeholderProperty());
-
         listView.getSelectionModel().selectedItemProperty().addListener(it -> control.getSearchField().setSelectedItem(listView.getSelectionModel().getSelectedItem()));
         registerEventListener();
     }


### PR DESCRIPTION

- Eliminated unnecessary `prefWidth` and `maxWidth` bindings to streamline bindings and reduce complexity.