### PR TITLE
making search results at the top optional and trusting the user's sorting method

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/SearchField.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/SearchField.java
@@ -112,6 +112,7 @@ public class SearchField<T> extends Control {
 
     private final SearchFieldPopup<T> popup;
     private final HistoryButton<String> historyButton;
+    
 
     /**
      * Constructs a new spotlight field. The field will set defaults for the
@@ -537,6 +538,26 @@ public class SearchField<T> extends Control {
 
     public final boolean isSearching() {
         return searching.get();
+    }
+    
+    public final BooleanProperty searchResultsOnTop = new SimpleBooleanProperty(this, "searchResultsOnTop", true);
+
+    public final boolean isSearchResultsOnTop() {
+        return searchResultsOnTop.get();
+    }
+
+    /**
+     * Shows results matching searched text at the top of the search results, this may be turned off when search item
+     * order has special requirements. The default is "true".
+     *
+     * @return true if the popup showing the list of suggestions will show search matched terms first when available
+     */
+    public final BooleanProperty searchResultsOnTopProperty() {
+        return searchResultsOnTop;
+    }
+
+    public final void setSearchResultsOnTop(boolean searchResultsOnTop) {
+        this.searchResultsOnTop.set(searchResultsOnTop);
     }
 
     private final BooleanProperty hidePopupWithSingleChoice = new SimpleBooleanProperty(this, "hidePopupWithSingleChoice", false);

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SearchFieldPopupSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SearchFieldPopupSkin.java
@@ -6,6 +6,7 @@
 package com.dlsc.gemsfx.skins;
 
 import com.dlsc.gemsfx.SearchField;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.transformation.SortedList;
 import javafx.scene.Node;
 import javafx.scene.control.ListView;
@@ -66,23 +67,25 @@ public class SearchFieldPopupSkin<T> implements Skin<SearchFieldPopup<T>> {
                 }
             }
 
-            // prefer the suggestions that start with the search term
-            StringConverter<T> converter = searchField.getConverter();
-            String searchText = searchField.getText().toLowerCase();
+            if(searchField.searchResultsOnTop.get()) {
+                // prefer the suggestions that start with the search term
+                StringConverter<T> converter = searchField.getConverter();
+                String searchText = searchField.getText().toLowerCase();
 
-            String text1 = converter.toString(o1).toLowerCase();
-            String text2 = converter.toString(o2).toLowerCase();
+                String text1 = converter.toString(o1).toLowerCase();
+                String text2 = converter.toString(o2).toLowerCase();
 
-            if (text1.startsWith(searchText) && text2.startsWith(searchText)) {
-                return text1.compareTo(text2);
-            }
+                if (text1.startsWith(searchText) && text2.startsWith(searchText)) {
+                    return result;//Both items are on equal footing, trust the custom comparator
+                }
 
-            if (text1.startsWith(searchText)) {
-                result = -1;
-            }
+                if (text1.startsWith(searchText)) {
+                    result = -1;
+                }
 
-            if (text2.startsWith(searchText)) {
-                result = 1;
+                if (text2.startsWith(searchText)) {
+                    result = 1;
+                }
             }
 
             return result;


### PR DESCRIPTION
I had an issue where the sorting order was important to the user and as soon as they started typing to search it was wrong. I tracked that down to the inner comparator where default alphanumeric is used when both terms match the search. Instead I've set both terms to use the custom comparator when both are valid results, maintaining order.

I've also added a property for whether search results are shown at the top of the list, useful when users do not want items shown out of order. Default value maintains previous functionality.