### PR TITLE
Making the search field's search thread safe and interruptible

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/HistoryButton.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/HistoryButton.java
@@ -1,7 +1,6 @@
 package com.dlsc.gemsfx;
 
 import com.dlsc.gemsfx.util.HistoryManager;
-import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.*;
 import javafx.css.PseudoClass;
@@ -67,29 +66,32 @@ public class HistoryButton<T> extends Button {
     }
 
     /**
-     * Shows the popup that includes the list view with the items stored by the history manager.
+     * Toggles visibility of the popup that includes the list view with the items stored by the history manager.
      */
     public void showPopup() {
         Node owner = getOwner();
 
+        boolean hasHistory = getHistoryManager() != null;
+
+        if (hasHistory) {
+            if (popup == null) {
+                popup = new HistoryPopup();
+                popupShowing.bind(popup.showingProperty());
+            }
+
+            if (popup.isShowing()) {
+                hidePopup();
+            }
+            else {
+                popup.show(this);
+            }
+        }
+
+        //begin showing history BEFORE focusing owner, so that owner can sense that history is about to show
         if (owner != null && owner != this && !owner.isFocused()) {
             owner.requestFocus();
         }
 
-        if (getHistoryManager() == null) {
-            return;
-        }
-
-        if (popup == null) {
-            popup = new HistoryPopup();
-            popupShowing.bind(popup.showingProperty());
-        }
-
-        if (popup.isShowing()) {
-            hidePopup();
-        } else {
-            popup.show(this);
-        }
     }
 
     /**

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/SearchField.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/SearchField.java
@@ -1,26 +1,14 @@
 package com.dlsc.gemsfx;
 
-import com.dlsc.gemsfx.skins.SearchFieldPopup;
-import com.dlsc.gemsfx.skins.SearchFieldSkin;
 import com.dlsc.gemsfx.util.HistoryManager;
 import com.dlsc.gemsfx.util.StringHistoryManager;
+import com.dlsc.gemsfx.skins.SearchFieldPopup;
+import com.dlsc.gemsfx.skins.SearchFieldSkin;
 import javafx.animation.Animation;
 import javafx.animation.RotateTransition;
+import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.DoubleProperty;
-import javafx.beans.property.ListProperty;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.ReadOnlyBooleanProperty;
-import javafx.beans.property.ReadOnlyBooleanWrapper;
-import javafx.beans.property.ReadOnlyStringProperty;
-import javafx.beans.property.ReadOnlyStringWrapper;
-import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleDoubleProperty;
-import javafx.beans.property.SimpleListProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
+import javafx.beans.property.*;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.concurrent.Service;
@@ -30,13 +18,7 @@ import javafx.event.Event;
 import javafx.event.EventHandler;
 import javafx.event.EventType;
 import javafx.scene.Node;
-import javafx.scene.control.ContentDisplay;
-import javafx.scene.control.Control;
-import javafx.scene.control.Label;
-import javafx.scene.control.ListCell;
-import javafx.scene.control.ListView;
-import javafx.scene.control.Skin;
-import javafx.scene.control.TextField;
+import javafx.scene.control.*;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
@@ -55,6 +37,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
@@ -142,29 +125,43 @@ public class SearchField<T> extends Control {
         setPlaceholder(new Label("No items found"));
 
         focusedProperty().addListener(it -> {
-            if (isFocused()) {
+            if (isFocused() && !historyButton.isPopupShowing()) {
                 getEditor().requestFocus();
             }
         });
 
         editor.focusedProperty().addListener(it -> {
-            if (!isAutoCommitOnFocusLost()) {
+            if (!isAutoCommitOnFocusLost() && !isFocusWithin()) {
                 if (popup.isShowing()) {
                     popup.hide();
+                    cancel();
+                    return;
                 }
-                return;
             }
 
-            if (!editor.isFocused()) {
+            boolean focused = editor.isFocused();
+            boolean blank = StringUtils.isBlank(editor.getText());
+            String searchText = editor.getText();
+
+            if (isAutoCommitOnFocusLost() && !focused) {
+
                 // Add the current text to the history if the editor lost focus.
                 if (isAddingItemToHistoryOnFocusLost()) {
-                    addToHistory(editor.getText());
+                    addToHistory(searchText);
                 }
-                commit();
-                if (getSelectedItem() == null) {
-                    editor.setText("");
+
+                T defaultChoice = getSearchDefaultChoice(searchText);
+                if(defaultChoice == null && newItemProducer.get() != null) {
+                    T newItem = newItemProducer.get().call(searchText);
+                    select(newItem);
+                } else
+                    commit();
+            }
+            else if (focused && !blank) {
+                if (!Objects.equals(searchService.text, searchText)) {
+                    restartSearch();
                 } else {
-                    invokeCommitHandler();
+                    popup.showPopup();
                 }
             }
         });
@@ -227,11 +224,15 @@ public class SearchField<T> extends Control {
         fullText.bind(Bindings.createStringBinding(() -> editor.getText() + getAutoCompletedText(), editor.textProperty(), autoCompletedText));
 
         editor.textProperty().addListener(it -> {
-            if (!committing) {
-                if (StringUtils.isNotBlank(editor.getText())) {
-                    searchService.restart();
+            //we should always be focused while text is changing?
+            boolean focused = editor.isFocused();
+            boolean blank = StringUtils.isBlank(editor.getText());
+
+            if (focused && !committing) {
+                if (!blank) {
+                    restartSearch();
                 } else {
-                    update(null);
+                    clearSuggestions();
                 }
             }
         });
@@ -242,7 +243,7 @@ public class SearchField<T> extends Control {
                 String displayName = getConverter().toString(selectedItem);
                 String text = editor.getText();
 
-                if (StringUtils.isBlank(text)) {
+                if (!getPopup().isShowing() && StringUtils.isBlank(text)) {
                     /*
                      * Looks like the "selected item" was set from outside, and not because of a search.
                      * We are using the "committing" flag so that the listener that responds to editor text
@@ -255,14 +256,10 @@ public class SearchField<T> extends Control {
                         committing = false;
                     }
                 } else {
-                    if (StringUtils.startsWithIgnoreCase(displayName, text)) {
-                        autoCompletedText.set(displayName.substring(text.length()));
-                    } else {
-                        autoCompletedText.set("");
-                    }
+                    updateAutoSuggestionText();
                 }
             } else {
-                autoCompletedText.set("");
+                updateAutoSuggestionText();
             }
         });
 
@@ -322,10 +319,72 @@ public class SearchField<T> extends Control {
 
         searchService.setOnSucceeded(evt -> {
             update(searchService.getValue());
+            updateAutoSuggestionText();
             fireEvent(new SearchEvent(SearchEvent.SEARCH_FINISHED, searchService.getText()));
         });
 
         searching.bind(searchService.runningProperty());
+    }
+
+    protected void updateAutoSuggestionText() {
+        String searchText = editor.getText();
+
+        T defaultChoice = getSearchDefaultChoice(searchText);
+
+        if(defaultChoice != null) {
+            String suggestionText = getConverter().toString(defaultChoice);
+            if (StringUtils.startsWithIgnoreCase(suggestionText, searchText)) {
+                autoCompletedText.set(suggestionText.substring(searchText.length()));
+                return;
+            }
+        }
+
+        autoCompletedText.set("");
+    }
+
+    private T getSearchDefaultChoice(String searchText) {
+        BiFunction<T, String, Boolean> matcher = getMatcher();
+        T defaultChoice = suggestions.stream().sorted(comparator.get()).filter(item -> matcher.apply(item, searchText)).findFirst().orElse(null);
+
+        if(selectedItem.get() != null && StringUtils.startsWithIgnoreCase(getConverter().toString(defaultChoice), searchText))
+            defaultChoice = selectedItem.get();
+
+        return defaultChoice;
+    }
+
+    public synchronized void restartSearch(){
+        safeInvoke(()->{
+            switch (searchService.getState()) {
+                case READY, SUCCEEDED, FAILED, CANCELLED, RUNNING -> {
+                    try {
+                        searchService.restart();
+                    } catch (Exception ex) {
+                        searchService.text = editor.getText();
+                    }
+                }
+                case SCHEDULED ->
+                    searchService.text = editor.getText();
+            }
+        });
+    }
+
+
+    /**
+     * adds the runnable to the ui queue if not already in the ui thread.
+     * if this is called in the ui thread, the action is taken immediately
+     *
+     * @param r
+     */
+    private static void safeInvoke(Runnable r) {
+        if (!onUIThread()) {
+            Platform.runLater(r);
+        }
+        else {
+            r.run();
+        }
+    }
+    private static boolean onUIThread() {
+        return Thread.currentThread().getName().equals("JavaFX Application Thread");
     }
 
     private void onHistoryItemConfirmed(String historyItem) {
@@ -359,11 +418,9 @@ public class SearchField<T> extends Control {
 
     private void invokeCommitHandler() {
         T selectedItem = getSelectedItem();
-        if (selectedItem != null) {
-            Consumer<T> onCommit = getOnCommit();
-            if (onCommit != null) {
-                onCommit.accept(selectedItem);
-            }
+        Consumer<T> onCommit = getOnCommit();
+        if (onCommit != null) {
+            onCommit.accept(selectedItem);
         }
     }
 
@@ -382,6 +439,7 @@ public class SearchField<T> extends Control {
             if (selectedItem != null) {
                 String text = getConverter().toString(selectedItem);
                 if (text != null) {
+                    lastUserText = editor.getText();
                     editor.setText(text);
                     editor.positionCaret(text.length());
 
@@ -397,9 +455,12 @@ public class SearchField<T> extends Control {
             }
 
             getProperties().put("committed", "");
+
+            invokeCommitHandler();
         } finally {
             committing = false;
         }
+
     }
 
     private void addToHistory(String text) {
@@ -430,6 +491,10 @@ public class SearchField<T> extends Control {
 
     public void setOnCommit(Consumer<T> onCommit) {
         this.onCommit.set(onCommit);
+    }
+
+    public boolean isCommitting() {
+        return committing;
     }
 
     private class SearchEventHandlerProperty extends SimpleObjectProperty<EventHandler<SearchEvent>> {
@@ -565,6 +630,17 @@ public class SearchField<T> extends Control {
         return hidePopupWithNoChoice.get();
     }
 
+
+    //User's search text when a searched object is not selected. Useful for advanced filtering
+    private String lastUserText = null;
+
+    /**
+     * @return The user's search text when a searched object is not selected. Useful for advanced filtering
+     */
+    public final String getLastUserText(){
+        return lastUserText;
+    }
+
     /**
      * Determines whether to hide the popup window when there are no choices available in the suggestion list.
      * The default value is "false", indicating that the popup does not hide automatically under this condition.
@@ -660,12 +736,15 @@ public class SearchField<T> extends Control {
      * Cancels the current search in progress.
      */
     public final void cancel() {
-        searchService.cancel();
         getProperties().put("cancelled", "");
-        setSelectedItem(null);
-        setText("");
+        if(popup.isShowing())
+            popup.hide();
+        searchService.cancel();
     }
 
+    protected void clearSuggestions(){
+        suggestions.clear();
+    }
     /**
      * Updates the control with the newly found list of suggestions. The suggestions
      * are provided by a background search service.
@@ -673,33 +752,22 @@ public class SearchField<T> extends Control {
      * @param newSuggestions the new suggestions to use for the field
      */
     protected void update(Collection<T> newSuggestions) {
-        if (newSuggestions == null) {
-            suggestions.clear();
+        if (newSuggestions == null || newSuggestions.isEmpty()) {
+            clearSuggestions();
             return;
         }
 
         suggestions.setAll(newSuggestions);
 
         String searchText = editor.getText();
+
         if (StringUtils.isNotBlank(searchText)) {
             try {
-                BiFunction<T, String, Boolean> matcher = getMatcher();
-
+                T defaultChoice = getSearchDefaultChoice(searchText);
                 newItem.set(false);
 
-                newSuggestions.stream().filter(item -> matcher.apply(item, searchText)).findFirst().ifPresentOrElse(selectedItem::set, () -> {
-                    if (StringUtils.isNotBlank(searchText)) {
-                        Callback<String, T> itemProducer = getNewItemProducer();
-                        if (itemProducer != null) {
-                            newItem.set(true);
-                            selectedItem.set(itemProducer.call(searchText));
-                        } else {
-                            selectedItem.set(null);
-                        }
-                    } else {
-                        selectedItem.set(null);
-                    }
-                });
+                selectedItem.set(defaultChoice);
+
             } catch (Exception ex) {
                 ex.printStackTrace();
             }
@@ -1311,14 +1379,14 @@ public class SearchField<T> extends Control {
      * A typical delay may be less than a second. 100-250.
      * </p>
      */
-    public final LongProperty searchDelayMs = new SimpleLongProperty(this, "searchDelayMs", 250);
+    public final LongProperty searchDelayMs = new SimpleLongProperty(this, "searchDelayMs", 0);
     
     public final long getSearchDelayMs() {
         return searchDelayMs.get();
     }
 
     public final void setSearchDelayMs(long searchDelayMs) {
-        searchDelayMs.set(searchDelayMs);
+        this.searchDelayMs.set(searchDelayMs);
     }
     
     /**

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SearchFieldPopup.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SearchFieldPopup.java
@@ -7,6 +7,7 @@ package com.dlsc.gemsfx.skins;
 
 import com.dlsc.gemsfx.CustomPopupControl;
 import com.dlsc.gemsfx.SearchField;
+import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableList;
@@ -15,6 +16,8 @@ import javafx.scene.control.Skin;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SearchFieldPopup<T> extends CustomPopupControl {
 
@@ -37,9 +40,15 @@ public class SearchFieldPopup<T> extends CustomPopupControl {
         MapChangeListener<? super Object, ? super Object> l = change -> {
             if (change.wasAdded()) {
                 if (change.getKey().equals("committed") || change.getKey().equals("cancelled")) {
-                    hide();
-                    searchField.getProperties().remove("committed");
-                    searchField.getProperties().remove("cancelled");
+                    try {
+                        blockingInvoke(()->{
+                            hide();
+                            searchField.getProperties().remove("committed");
+                            searchField.getProperties().remove("cancelled");
+                        });
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
             }
         };
@@ -66,8 +75,8 @@ public class SearchFieldPopup<T> extends CustomPopupControl {
                 }
 
                 if (showIt) {
-                    show(searchField);
-                    selectFirstSuggestion();
+                    showPopup();
+//                    selectFirstSuggestion();
                 } else {
                     hide();
                 }
@@ -75,6 +84,34 @@ public class SearchFieldPopup<T> extends CustomPopupControl {
                 hide();
             }
         });
+    }
+
+    /**
+     * block on the current thread until the ui invocation has completed.
+     * this is mostly useful for starting transitions or modifying ui elements off the ui thread
+     *
+     * @param r
+     */
+    public static void blockingInvoke(Runnable r) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+
+
+        if (!Thread.currentThread().getName().equals("JavaFX Application Thread")) {
+            Platform.runLater(() -> {
+                r.run();
+                latch.countDown();
+            });
+        }
+        else {
+            r.run();
+            latch.countDown();
+        }
+
+        latch.await();
+    }
+
+    public void showPopup(){
+        show(searchField);
     }
 
     public SearchField<T> getSearchField() {

--- a/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SearchFieldPopupSkin.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/skins/SearchFieldPopupSkin.java
@@ -103,11 +103,6 @@ public class SearchFieldPopupSkin<T> implements Skin<SearchFieldPopup<T>> {
         T selectedItem = listView.getSelectionModel().getSelectedItem();
         if (selectedItem != null) {
             searchField.select(selectedItem);
-            searchField.commit();
-            Consumer<T> onCommit = searchField.getOnCommit();
-            if (onCommit != null) {
-                onCommit.accept(selectedItem);
-            }
         }
     }
 


### PR DESCRIPTION
I've pulled this out of my too big pull request from a few months ago. I've tried to keep all of my extra functionality out of this branch for now. 

The search has a delay on it which made searches less responsive. I tracked this back to concurrency issues with the search. So I've made the search thread safe and clearly interruptible. 

This may look like a lot of changes but most everywhere that interacted with starting a search just needed to be modified a little bit. 

With this change functionality should be essentially the same, but more responsive/lower latency. Because it should be safe, and only snappier, I've gone ahead and set the delay to 0ms.