### PR TITLE
fix(DialogPane): bind visibility of header and footer to dialog properties

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/DialogPane.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/DialogPane.java
@@ -1893,13 +1893,16 @@ public class DialogPane extends StackPane {
 
             boolean blankDialog = this.dialog.getType().equals(Type.BLANK);
 
-            header.setVisible(!blankDialog && dialog.isShowHeader());
-            header.setManaged(!blankDialog && dialog.isShowHeader());
+            header.visibleProperty().bind(Bindings.createBooleanBinding(() -> !blankDialog && dialog.isShowHeader()
+                    , dialog.showHeaderProperty()));
+            header.managedProperty().bind(header.visibleProperty());
 
             Node footer = getFooterFactory().call(dialog);
             VBox.setVgrow(footer, Priority.NEVER);
-            footer.setVisible(!blankDialog && dialog.isShowFooter());
-            footer.setManaged(!blankDialog && dialog.isShowFooter());
+
+            footer.visibleProperty().bind(Bindings.createBooleanBinding(() -> !blankDialog && dialog.isShowFooter()
+                    , dialog.showFooterProperty()));
+            footer.managedProperty().bind(footer.visibleProperty());
 
             dialog.getStyleClass().addListener(weakUpdateStyleClassesListener);
             updateContentPaneStyleClasses();


### PR DESCRIPTION

Currently, the visibility of dialog headers and footers is only read once during ContentPane construction. Calling dialog.setShowHeader(false) or dialog.setShowFooter(false) after show() has no effect because the visibility properties are not bound.


Changed from direct property assignment to property binding in the ContentPane constructor: