### PR TITLE
Fix YearMonthPicker keyboard event firing twice

### DIFF
--- a/gemsfx/src/main/java/com/dlsc/gemsfx/YearMonthPicker.java
+++ b/gemsfx/src/main/java/com/dlsc/gemsfx/YearMonthPicker.java
@@ -52,7 +52,7 @@ public class YearMonthPicker extends CustomComboBox<YearMonth> {
             pseudoClassStateChanged(PseudoClass.getPseudoClass("focused"), editor.isFocused());
         });
 
-        editor.addEventHandler(KeyEvent.ANY, evt -> {
+        editor.addEventHandler(KeyEvent.KEY_PRESSED, evt -> {
             if (evt.getCode().equals(KeyCode.DOWN)) {
                 setValue(getValue().plusMonths(1));
             } else if (evt.getCode().equals(KeyCode.UP)) {


### PR DESCRIPTION
Replace `KeyEvent.ANY` with `KeyEvent.KEY_PRESSED` in YearMonthPicker to prevent UP/DOWN key handlers from firing multiple times per keystroke.

**Before:** Pressing DOWN once jumps 2 months  
**After:** Pressing DOWN once jumps 1 month